### PR TITLE
[codex] optimize aquarium performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 
 ## Active Technologies
 - TypeScript + Three.js 0.161, Vite 7, Vitest 4, authored Pure CSS, vite-plugin-glsl 1.5
-- Playwright is retained as a dev dependency for `scripts/capture-aquarium-screenshot.mjs`; `@types/three` remains required for TypeScript typecheck coverage over Three.js APIs.
+- Playwright is retained as a dev dependency for local screenshot/performance tooling (`scripts/capture-aquarium-screenshot.mjs`, `scripts/measure-aquarium-performance.mjs`); `@types/three` remains required for TypeScript typecheck coverage over Three.js APIs.
 - localStorage（ゲーム保存/旧保存形式マイグレーション）、インメモリ（カレント状態）
 
 ## Recent Changes

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "generate:fish-assets": "node scripts/generate-fish-assets.mjs",
+    "measure:performance": "node scripts/measure-aquarium-performance.mjs",
     "screenshot": "node scripts/capture-aquarium-screenshot.mjs",
     "build": "tsc && vite build",
     "preview": "vite preview",

--- a/scripts/measure-aquarium-performance.mjs
+++ b/scripts/measure-aquarium-performance.mjs
@@ -1,0 +1,251 @@
+import { chromium as defaultChromium } from 'playwright'
+import { promises as defaultFs } from 'node:fs'
+
+const defaultUrl = 'http://127.0.0.1:5173/meaningless/'
+const defaultOutputPath = '/tmp/meaningless-aquarium-performance.json'
+const defaultDurationMs = 30_000
+
+/**
+ * @typedef {{
+ *   launch: (options: { headless: boolean }) => Promise<{
+ *     newPage: (options: { viewport: { width: number, height: number } }) => Promise<any>,
+ *     close: () => Promise<unknown> | unknown
+ *   }>
+ * }} PerformanceChromium
+ *
+ * @typedef {{
+ *   writeFile: (path: string, data: string) => Promise<unknown> | unknown
+ * }} PerformanceFs
+ *
+ * @typedef {{
+ *   chromium?: PerformanceChromium,
+ *   fs?: PerformanceFs,
+ *   url?: string,
+ *   outputPath?: string,
+ *   durationMs?: number,
+ *   width?: number,
+ *   height?: number,
+ *   headless?: boolean
+ * }} MeasureAquariumPerformanceOptions
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+const toFiniteNumber = (value) => (
+  typeof value === 'number' && Number.isFinite(value) ? value : 0
+)
+
+/**
+ * @param {number} value
+ * @returns {number}
+ */
+const roundOneDecimal = (value) => Math.round(value * 10) / 10
+
+/**
+ * @param {number[]} sortedValues
+ * @param {number} percentileRank
+ * @returns {number}
+ */
+const percentile = (sortedValues, percentileRank) => {
+  if (sortedValues.length === 0) return 0
+  const index = Math.max(0, Math.ceil(sortedValues.length * percentileRank) - 1)
+  return sortedValues[Math.min(sortedValues.length - 1, index)]
+}
+
+/**
+ * @param {string | undefined} value
+ * @returns {number | null}
+ */
+const parseShadowMapSize = (value) => {
+  if (!value) return null
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed)) return null
+  return parsed >= 512 && parsed <= 4096 ? parsed : null
+}
+
+/**
+ * @param {string} url
+ * @param {Record<string, string | undefined>} env
+ * @returns {string}
+ */
+export const resolveMeasurementUrl = (url, env = process.env) => {
+  const measurementUrl = new URL(url)
+  if (env.AQUARIUM_PERFORMANCE_POST_PROCESSING === '0') {
+    measurementUrl.searchParams.set('perfPost', '0')
+  }
+  if (env.AQUARIUM_PERFORMANCE_HAZE === '0') {
+    measurementUrl.searchParams.set('perfHaze', '0')
+  }
+  const shadowMapSize = parseShadowMapSize(env.AQUARIUM_PERFORMANCE_SHADOW_MAP_SIZE)
+  if (shadowMapSize !== null) {
+    measurementUrl.searchParams.set('perfShadow', String(shadowMapSize))
+  }
+  return measurementUrl.toString()
+}
+
+/**
+ * @param {unknown[]} frameTimes
+ * @returns {{
+ *   sampleCount: number,
+ *   averageMs: number,
+ *   minMs: number,
+ *   p50Ms: number,
+ *   p95Ms: number,
+ *   maxMs: number
+ * }}
+ */
+export const summarizeFrameTimes = (frameTimes) => {
+  const samples = frameTimes
+    .map(toFiniteNumber)
+    .filter((value) => value >= 0)
+    .sort((a, b) => a - b)
+
+  if (samples.length === 0) {
+    return {
+      sampleCount: 0,
+      averageMs: 0,
+      minMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+      maxMs: 0
+    }
+  }
+
+  const total = samples.reduce((sum, value) => sum + value, 0)
+
+  return {
+    sampleCount: samples.length,
+    averageMs: roundOneDecimal(total / samples.length),
+    minMs: roundOneDecimal(samples[0]),
+    p50Ms: roundOneDecimal(percentile(samples, 0.5)),
+    p95Ms: roundOneDecimal(percentile(samples, 0.95)),
+    maxMs: roundOneDecimal(samples[samples.length - 1])
+  }
+}
+
+/**
+ * @param {unknown} stats
+ */
+const normalizeAppStats = (stats) => {
+  const source = stats && typeof stats === 'object'
+    ? /** @type {Record<string, unknown>} */ (stats)
+    : {}
+
+  return {
+    fps: toFiniteNumber(source.fps),
+    frameTime: toFiniteNumber(source.frameTime),
+    drawCalls: toFiniteNumber(source.drawCalls),
+    triangles: toFiniteNumber(source.triangles),
+    geometries: toFiniteNumber(source.geometries),
+    textures: toFiniteNumber(source.textures),
+    fishVisible: toFiniteNumber(source.fishVisible),
+    assetLoadTotalMs: toFiniteNumber(source.assetLoadTotalMs),
+    assetLoadTexturesMs: toFiniteNumber(source.assetLoadTexturesMs),
+    assetLoadModelsMs: toFiniteNumber(source.assetLoadModelsMs),
+    assetLoadEnvironmentMs: toFiniteNumber(source.assetLoadEnvironmentMs),
+    fishUpdateCount: toFiniteNumber(source.fishUpdateCount),
+    fishUpdateLastMs: toFiniteNumber(source.fishUpdateLastMs),
+    fishUpdateAverageMs: toFiniteNumber(source.fishUpdateAverageMs),
+    waterMotionUpdateCount: toFiniteNumber(source.waterMotionUpdateCount),
+    waterMotionUpdateLastMs: toFiniteNumber(source.waterMotionUpdateLastMs),
+    waterMotionUpdateAverageMs: toFiniteNumber(source.waterMotionUpdateAverageMs),
+    godRaysDepthRenderCount: toFiniteNumber(source.godRaysDepthRenderCount),
+    godRaysDepthRenderLastMs: toFiniteNumber(source.godRaysDepthRenderLastMs),
+    godRaysDepthRenderAverageMs: toFiniteNumber(source.godRaysDepthRenderAverageMs)
+  }
+}
+
+/**
+ * @param {{ evaluate: (fn: (sampleDurationMs: number) => Promise<{ frameTimes: number[], appStats: unknown }>, durationMs: number) => Promise<{ frameTimes: number[], appStats: unknown }> }} page
+ * @param {number} durationMs
+ */
+const collectFrameSamples = async (page, durationMs) => page.evaluate(async (sampleDurationMs) => {
+  /** @type {number[]} */
+  const frameTimes = []
+  const sampleStart = performance.now()
+  /** @type {number | null} */
+  let previousFrameTime = null
+
+  await new Promise(/** @param {(value: unknown) => void} resolve */ (resolve) => {
+    /** @param {number} now */
+    const tick = (now) => {
+      if (previousFrameTime !== null) {
+        frameTimes.push(now - previousFrameTime)
+      }
+      previousFrameTime = now
+
+      if (now - sampleStart >= sampleDurationMs) {
+        resolve(null)
+        return
+      }
+
+      requestAnimationFrame(tick)
+    }
+
+    requestAnimationFrame(tick)
+  })
+
+  const debugWindow = /** @type {Window & { __aquariumPerformanceStats?: () => unknown }} */ (window)
+
+  return {
+    frameTimes,
+    appStats: typeof debugWindow.__aquariumPerformanceStats === 'function'
+      ? debugWindow.__aquariumPerformanceStats()
+      : null
+  }
+}, durationMs)
+
+/**
+ * @param {MeasureAquariumPerformanceOptions} [options]
+ */
+export const measureAquariumPerformance = async ({
+  chromium = defaultChromium,
+  fs = defaultFs,
+  url = resolveMeasurementUrl(defaultUrl),
+  outputPath = defaultOutputPath,
+  durationMs = defaultDurationMs,
+  width = 1368,
+  height = 768,
+  headless = false
+} = {}) => {
+  const browser = await chromium.launch({ headless })
+
+  try {
+    const page = await browser.newPage({ viewport: { width, height } })
+    await page.goto(url, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(1000)
+
+    const sample = await collectFrameSamples(page, durationMs)
+    const result = {
+      url,
+      durationMs,
+      viewport: { width, height },
+      headless,
+      frameTime: summarizeFrameTimes(sample.frameTimes),
+      appStats: normalizeAppStats(sample.appStats)
+    }
+
+    await fs.writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`)
+    return result
+  } finally {
+    await browser.close()
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const outputPath = process.argv[2] ?? process.env.AQUARIUM_PERFORMANCE_OUTPUT ?? defaultOutputPath
+  const url = resolveMeasurementUrl(process.env.AQUARIUM_PERFORMANCE_URL ?? defaultUrl)
+  const durationMs = Number(process.env.AQUARIUM_PERFORMANCE_DURATION_MS ?? defaultDurationMs)
+  const headless = process.env.AQUARIUM_PERFORMANCE_HEADLESS === '1'
+
+  measureAquariumPerformance({ outputPath, url, durationMs, headless })
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2))
+    })
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
+}

--- a/src/AdvancedAquariumApp.ts
+++ b/src/AdvancedAquariumApp.ts
@@ -11,9 +11,19 @@ import { loadProfileState } from './utils/profileStorage'
 import { loadSettingsState } from './utils/settingsStorage'
 import { getAutoSave } from './utils/storage'
 import { loadTankState } from './utils/tankStorage'
-import { loadVisualAssets, type VisualAssetBundle } from './assets/visualAssets'
+import {
+  createBootAquariumAssetManifest,
+  createDeferredAquariumAssetManifest,
+  loadVisualAssets,
+  type VisualAssetBundle
+} from './assets/visualAssets'
+import { createEmptyPerformanceStats, type PerformanceStats } from './utils/performanceStats'
+import { resolvePerformanceTuningOptions } from './utils/performanceTuning'
 
 type ControlPaneHandle = ReturnType<typeof createGameControlPane>
+type AquariumDebugWindow = Window & {
+  __aquariumPerformanceStats?: () => PerformanceStats
+}
 
 export class AdvancedAquariumApp {
   private scene: AdvancedAquariumScene | null = null
@@ -62,6 +72,7 @@ export class AdvancedAquariumApp {
   }
 
   private async init(): Promise<void> {
+    performance.mark('aquarium:app:init:start')
     this.showLoadingScreen()
     await this.loadAssets()
 
@@ -72,13 +83,21 @@ export class AdvancedAquariumApp {
     this.scene = new AdvancedAquariumScene(
       container,
       this.visualAssets ?? undefined,
-      initialTheme
+      initialTheme,
+      resolvePerformanceTuningOptions(window.location.search)
     )
     this.setupControlPane()
     this.setupStoreBinding()
     this.setupEventListeners()
     this.scene.start()
+    this.setupPerformanceDebugHook()
     this.hideLoadingScreen()
+    performance.mark('aquarium:loading-overlay:hidden')
+    performance.measure(
+      'aquarium:app:init-to-overlay-hidden',
+      'aquarium:app:init:start',
+      'aquarium:loading-overlay:hidden'
+    )
   }
 
   private showLoadingScreen(): void {
@@ -90,7 +109,31 @@ export class AdvancedAquariumApp {
   }
 
   private async loadAssets(): Promise<void> {
-    this.visualAssets = await loadVisualAssets()
+    this.visualAssets = await loadVisualAssets(createBootAquariumAssetManifest())
+    void this.loadDeferredAssets()
+  }
+
+  private async loadDeferredAssets(): Promise<void> {
+    const deferredManifest = createDeferredAquariumAssetManifest()
+    if (
+      deferredManifest.textures.length === 0 &&
+      deferredManifest.models.length === 0 &&
+      deferredManifest.environment.length === 0
+    ) {
+      return
+    }
+
+    const deferredAssets = await loadVisualAssets(deferredManifest)
+    if (!this.visualAssets) return
+
+    this.visualAssets.manifest = {
+      textures: [...this.visualAssets.manifest.textures, ...deferredAssets.manifest.textures],
+      models: [...this.visualAssets.manifest.models, ...deferredAssets.manifest.models],
+      environment: [...this.visualAssets.manifest.environment, ...deferredAssets.manifest.environment]
+    }
+    Object.assign(this.visualAssets.textures, deferredAssets.textures)
+    Object.assign(this.visualAssets.models, deferredAssets.models)
+    Object.assign(this.visualAssets.environment, deferredAssets.environment)
   }
 
   private setupControlPane(): void {
@@ -99,14 +142,14 @@ export class AdvancedAquariumApp {
     }
     this.controlPane = createGameControlPane({
       store: this.store,
-      getPerformanceStats: () => this.scene?.getPerformanceStats() ?? {
-        fps: 0,
-        frameTime: 0,
-        drawCalls: 0,
-        fishVisible: 0
-      }
+      getPerformanceStats: () => this.scene?.getPerformanceStats() ?? createEmptyPerformanceStats()
     })
     document.body.appendChild(this.controlPane.element)
+  }
+
+  private setupPerformanceDebugHook(): void {
+    const debugWindow = window as AquariumDebugWindow
+    debugWindow.__aquariumPerformanceStats = () => this.scene?.getPerformanceStats() ?? createEmptyPerformanceStats()
   }
 
   private setupStoreBinding(): void {
@@ -174,6 +217,7 @@ export class AdvancedAquariumApp {
       this.scene = null
     }
 
+    delete (window as AquariumDebugWindow).__aquariumPerformanceStats
     this.audioManager.dispose()
   }
 }

--- a/src/AdvancedAquariumApp.ts
+++ b/src/AdvancedAquariumApp.ts
@@ -19,6 +19,7 @@ import {
 } from './assets/visualAssets'
 import { createEmptyPerformanceStats, type PerformanceStats } from './utils/performanceStats'
 import { resolvePerformanceTuningOptions } from './utils/performanceTuning'
+import type { GameAppState } from './game/types'
 
 type ControlPaneHandle = ReturnType<typeof createGameControlPane>
 type AquariumDebugWindow = Window & {
@@ -35,6 +36,7 @@ export class AdvancedAquariumApp {
   private motionMediaHandler: ((event: MediaQueryListEvent) => void) | null = null
   private keyHandler: ((event: KeyboardEvent) => void) | null = null
   private visualAssets: VisualAssetBundle | null = null
+  private applySceneState: ((state: GameAppState, options?: { forceFishGroups?: boolean }) => void) | null = null
 
   constructor() {
     const nowIso = new Date().toISOString()
@@ -134,6 +136,7 @@ export class AdvancedAquariumApp {
     Object.assign(this.visualAssets.textures, deferredAssets.textures)
     Object.assign(this.visualAssets.models, deferredAssets.models)
     Object.assign(this.visualAssets.environment, deferredAssets.environment)
+    this.applySceneState?.(this.store.getState(), { forceFishGroups: true })
   }
 
   private setupControlPane(): void {
@@ -163,6 +166,7 @@ export class AdvancedAquariumApp {
       scene,
       audioManager: this.audioManager
     })
+    this.applySceneState = applySceneState
 
     this.storeUnsubscribe = this.store.subscribe(({ state }) => {
       applySceneState(state)
@@ -204,6 +208,7 @@ export class AdvancedAquariumApp {
       this.storeUnsubscribe()
       this.storeUnsubscribe = null
     }
+    this.applySceneState = null
 
     this.store.destroy()
 

--- a/src/__tests__/advancedAquariumAppMotionPreference.test.ts
+++ b/src/__tests__/advancedAquariumAppMotionPreference.test.ts
@@ -60,11 +60,14 @@ vi.mock('../components/GameControlPane', () => {
 
 vi.mock('../assets/visualAssets', () => {
   return {
-    aquariumAssetManifest: { textures: [], models: [] },
+    aquariumAssetManifest: { textures: [], models: [], environment: [] },
+    createBootAquariumAssetManifest: vi.fn(() => ({ textures: [], models: [], environment: [] })),
+    createDeferredAquariumAssetManifest: vi.fn(() => ({ textures: [], models: [], environment: [] })),
     loadVisualAssets: vi.fn(async () => ({
-      manifest: { textures: [], models: [] },
+      manifest: { textures: [], models: [], environment: [] },
       textures: {},
-      models: {}
+      models: {},
+      environment: {}
     }))
   }
 })

--- a/src/__tests__/advancedAquariumAppUX.test.ts
+++ b/src/__tests__/advancedAquariumAppUX.test.ts
@@ -24,6 +24,7 @@ const hoisted = vi.hoisted(() => {
     lastSceneAssets: null as unknown,
     lastSceneOptions: null as unknown,
     lastSceneInstance: null as {
+      applyFishGroups: ReturnType<typeof vi.fn>
       getPerformanceStats: ReturnType<typeof vi.fn>
     } | null,
     lastPaneStatsProvider: null as null | (() => unknown)
@@ -51,6 +52,7 @@ vi.mock('../components/AdvancedScene', () => {
         hoisted.lastSceneAssets = assets ?? null
         hoisted.lastSceneOptions = options ?? null
         hoisted.lastSceneInstance = this as unknown as {
+          applyFishGroups: ReturnType<typeof vi.fn>
           getPerformanceStats: ReturnType<typeof vi.fn>
         }
       }
@@ -258,12 +260,14 @@ describe('AdvancedAquariumApp UX integration', () => {
     expect(hoisted.loadVisualAssets).toHaveBeenNthCalledWith(2, hoisted.deferredManifest)
     expect(hoisted.lastSceneAssets).toBe(bootAssets)
     expect((hoisted.lastSceneAssets as typeof bootAssets).textures.boot).toBe(bootTexture)
+    expect(hoisted.lastSceneInstance?.applyFishGroups).toHaveBeenCalledTimes(1)
 
     resolveDeferredAssets(deferredAssets)
     await flushMicrotasks()
 
     expect((hoisted.lastSceneAssets as typeof bootAssets & typeof deferredAssets).textures.deferred).toBe(deferredTexture)
     expect((hoisted.lastSceneAssets as typeof bootAssets & typeof deferredAssets).models['fish-goldfish-hero']).toBeNull()
+    expect(hoisted.lastSceneInstance?.applyFishGroups).toHaveBeenCalledTimes(2)
 
     app.dispose()
   })

--- a/src/__tests__/advancedAquariumAppUX.test.ts
+++ b/src/__tests__/advancedAquariumAppUX.test.ts
@@ -1,23 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AdvancedAquariumApp } from '../AdvancedAquariumApp'
 
-const hoisted = vi.hoisted(() => ({
-  mockedAssets: {
-    manifest: { textures: [], models: [] },
+const hoisted = vi.hoisted(() => {
+  type MockVisualAssets = {
+    manifest: { textures: unknown[]; models: unknown[]; environment: unknown[] }
+    textures: Record<string, unknown>
+    models: Record<string, unknown>
+    environment: Record<string, unknown>
+  }
+  const createEmptyAssets = (): MockVisualAssets => ({
+    manifest: { textures: [], models: [], environment: [] },
     textures: {},
-    models: {}
-  },
-  loadVisualAssets: vi.fn(async () => ({
-    manifest: { textures: [], models: [] },
-    textures: {},
-    models: {}
-  })),
-  lastSceneAssets: null as unknown,
-  lastSceneInstance: null as {
-    getPerformanceStats: ReturnType<typeof vi.fn>
-  } | null,
-  lastPaneStatsProvider: null as null | (() => unknown)
-}))
+    models: {},
+    environment: {}
+  })
+  const mockedAssets = createEmptyAssets()
+
+  return {
+    bootManifest: { textures: [{ id: 'boot-texture' }], models: [{ id: 'boot-model' }], environment: [] },
+    deferredManifest: { textures: [{ id: 'deferred-texture' }], models: [{ id: 'deferred-model' }], environment: [] },
+    mockedAssets,
+    loadVisualAssets: vi.fn(async (_manifest?: unknown): Promise<MockVisualAssets> => createEmptyAssets()),
+    lastSceneAssets: null as unknown,
+    lastSceneOptions: null as unknown,
+    lastSceneInstance: null as {
+      getPerformanceStats: ReturnType<typeof vi.fn>
+    } | null,
+    lastPaneStatsProvider: null as null | (() => unknown)
+  }
+})
 
 vi.mock('../components/AdvancedScene', () => {
   return {
@@ -36,8 +47,9 @@ vi.mock('../components/AdvancedScene', () => {
         drawCalls: 0
       }))
 
-      constructor(_container?: HTMLElement, assets?: unknown) {
+      constructor(_container?: HTMLElement, assets?: unknown, _theme?: unknown, options?: unknown) {
         hoisted.lastSceneAssets = assets ?? null
+        hoisted.lastSceneOptions = options ?? null
         hoisted.lastSceneInstance = this as unknown as {
           getPerformanceStats: ReturnType<typeof vi.fn>
         }
@@ -74,7 +86,9 @@ vi.mock('../components/GameControlPane', () => {
 
 vi.mock('../assets/visualAssets', () => {
   return {
-    aquariumAssetManifest: { textures: [], models: [] },
+    aquariumAssetManifest: { textures: [], models: [], environment: [] },
+    createBootAquariumAssetManifest: vi.fn(() => hoisted.bootManifest),
+    createDeferredAquariumAssetManifest: vi.fn(() => hoisted.deferredManifest),
     loadVisualAssets: hoisted.loadVisualAssets
   }
 })
@@ -123,6 +137,7 @@ const flushMicrotasks = async (): Promise<void> => {
 
 describe('AdvancedAquariumApp UX integration', () => {
   beforeEach(() => {
+    window.history.replaceState(null, '', '/meaningless/')
     document.body.innerHTML = `
       <div id="canvas-container"></div>
       <div id="loading-screen"></div>
@@ -202,8 +217,70 @@ describe('AdvancedAquariumApp UX integration', () => {
     const app = new AdvancedAquariumApp()
     await flushMicrotasks()
 
-    expect(hoisted.loadVisualAssets).toHaveBeenCalledTimes(1)
+    expect(hoisted.loadVisualAssets).toHaveBeenCalledTimes(2)
+    expect(hoisted.loadVisualAssets).toHaveBeenNthCalledWith(1, hoisted.bootManifest)
+    expect(hoisted.loadVisualAssets).toHaveBeenNthCalledWith(2, hoisted.deferredManifest)
     expect(hoisted.lastSceneAssets).toBe(hoisted.mockedAssets)
+
+    app.dispose()
+  })
+
+  it('loads boot visual assets before constructing the scene and defers optional assets', async () => {
+    vi.useFakeTimers()
+    const bootTexture = {}
+    const deferredTexture = {}
+    const bootAssets = {
+      manifest: hoisted.bootManifest,
+      textures: { boot: bootTexture },
+      models: {},
+      environment: {}
+    }
+    const deferredAssets = {
+      manifest: hoisted.deferredManifest,
+      textures: { deferred: deferredTexture },
+      models: { 'fish-goldfish-hero': null },
+      environment: {}
+    }
+    let resolveDeferredAssets: (assets: typeof deferredAssets) => void = () => undefined
+    const deferredLoad = new Promise<typeof deferredAssets>((resolve) => {
+      resolveDeferredAssets = resolve
+    })
+    hoisted.loadVisualAssets.mockImplementation((manifest?: unknown) => {
+      if (manifest === hoisted.bootManifest) return Promise.resolve(bootAssets)
+      if (manifest === hoisted.deferredManifest) return deferredLoad
+      return Promise.resolve(hoisted.mockedAssets)
+    })
+
+    const app = new AdvancedAquariumApp()
+    await flushMicrotasks()
+
+    expect(hoisted.loadVisualAssets).toHaveBeenNthCalledWith(1, hoisted.bootManifest)
+    expect(hoisted.loadVisualAssets).toHaveBeenNthCalledWith(2, hoisted.deferredManifest)
+    expect(hoisted.lastSceneAssets).toBe(bootAssets)
+    expect((hoisted.lastSceneAssets as typeof bootAssets).textures.boot).toBe(bootTexture)
+
+    resolveDeferredAssets(deferredAssets)
+    await flushMicrotasks()
+
+    expect((hoisted.lastSceneAssets as typeof bootAssets & typeof deferredAssets).textures.deferred).toBe(deferredTexture)
+    expect((hoisted.lastSceneAssets as typeof bootAssets & typeof deferredAssets).models['fish-goldfish-hero']).toBeNull()
+
+    app.dispose()
+  })
+
+  it('passes measurement tuning query switches into the scene constructor', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState(null, '', '/meaningless/?perfPost=0&perfHaze=0&perfShadow=2048')
+    hoisted.loadVisualAssets.mockResolvedValue(hoisted.mockedAssets)
+
+    const app = new AdvancedAquariumApp()
+    await flushMicrotasks()
+
+    expect(hoisted.lastSceneOptions).toEqual({
+      postProcessingEnabled: false,
+      screenSpaceHazeEnabled: false,
+      shadowMapSize: 2048
+    })
 
     app.dispose()
   })
@@ -221,5 +298,50 @@ describe('AdvancedAquariumApp UX integration', () => {
     expect(hoisted.lastSceneInstance?.getPerformanceStats).toHaveBeenCalledTimes(1)
 
     app.dispose()
+  })
+
+  it('exposes scene performance stats to tooling and removes the hook on dispose', async () => {
+    vi.useFakeTimers()
+    hoisted.loadVisualAssets.mockResolvedValue(hoisted.mockedAssets)
+
+    const app = new AdvancedAquariumApp()
+    await flushMicrotasks()
+
+    const debugWindow = window as typeof window & {
+      __aquariumPerformanceStats?: () => unknown
+    }
+
+    expect(debugWindow.__aquariumPerformanceStats?.()).toEqual({
+      fps: 60,
+      frameTime: 16,
+      fishVisible: 0,
+      drawCalls: 0
+    })
+
+    app.dispose()
+
+    expect(debugWindow.__aquariumPerformanceStats).toBeUndefined()
+  })
+
+  it('marks app initialization through loading overlay hidden for browser performance tooling', async () => {
+    vi.useFakeTimers()
+    const mark = vi.spyOn(performance, 'mark').mockImplementation(() => ({} as PerformanceMark))
+    const measure = vi.spyOn(performance, 'measure').mockImplementation(() => ({} as PerformanceMeasure))
+    hoisted.loadVisualAssets.mockResolvedValue(hoisted.mockedAssets)
+
+    const app = new AdvancedAquariumApp()
+    await flushMicrotasks()
+
+    expect(mark).toHaveBeenCalledWith('aquarium:app:init:start')
+    expect(mark).toHaveBeenCalledWith('aquarium:loading-overlay:hidden')
+    expect(measure).toHaveBeenCalledWith(
+      'aquarium:app:init-to-overlay-hidden',
+      'aquarium:app:init:start',
+      'aquarium:loading-overlay:hidden'
+    )
+
+    app.dispose()
+    mark.mockRestore()
+    measure.mockRestore()
   })
 })

--- a/src/__tests__/autosaveHydration.test.ts
+++ b/src/__tests__/autosaveHydration.test.ts
@@ -87,11 +87,14 @@ vi.mock('../components/GameControlPane', () => {
 
 vi.mock('../assets/visualAssets', () => {
   return {
-    aquariumAssetManifest: { textures: [], models: [] },
+    aquariumAssetManifest: { textures: [], models: [], environment: [] },
+    createBootAquariumAssetManifest: vi.fn(() => ({ textures: [], models: [], environment: [] })),
+    createDeferredAquariumAssetManifest: vi.fn(() => ({ textures: [], models: [], environment: [] })),
     loadVisualAssets: vi.fn(async () => ({
-      manifest: { textures: [], models: [] },
+      manifest: { textures: [], models: [], environment: [] },
       textures: {},
-      models: {}
+      models: {},
+      environment: {}
     }))
   }
 })

--- a/src/__tests__/measureAquariumPerformance.test.ts
+++ b/src/__tests__/measureAquariumPerformance.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  resolveMeasurementUrl,
+  measureAquariumPerformance,
+  summarizeFrameTimes
+} from '../../scripts/measure-aquarium-performance.mjs'
+
+describe('summarizeFrameTimes', () => {
+  it('returns p50 and p95 frame timing summaries in a stable shape', () => {
+    expect(summarizeFrameTimes([20, 10, 40, 30])).toEqual({
+      sampleCount: 4,
+      averageMs: 25,
+      minMs: 10,
+      p50Ms: 20,
+      p95Ms: 40,
+      maxMs: 40
+    })
+  })
+
+  it('uses zero fallback values when no frame samples are captured', () => {
+    expect(summarizeFrameTimes([])).toEqual({
+      sampleCount: 0,
+      averageMs: 0,
+      minMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+      maxMs: 0
+    })
+  })
+})
+
+describe('measureAquariumPerformance', () => {
+  it('resolves env-driven A/B switch query params for comparable measurements', () => {
+    expect(resolveMeasurementUrl('http://127.0.0.1:5173/meaningless/', {
+      AQUARIUM_PERFORMANCE_POST_PROCESSING: '0',
+      AQUARIUM_PERFORMANCE_HAZE: '0',
+      AQUARIUM_PERFORMANCE_SHADOW_MAP_SIZE: '2048'
+    })).toBe('http://127.0.0.1:5173/meaningless/?perfPost=0&perfHaze=0&perfShadow=2048')
+  })
+
+  it('captures browser frame samples and app debug stats into one comparable JSON object', async () => {
+    const writeFile = vi.fn()
+    const page = {
+      goto: vi.fn(),
+      waitForTimeout: vi.fn(),
+      evaluate: vi.fn(async () => ({
+        frameTimes: [12, 18, 24, 48],
+        appStats: {
+          drawCalls: 151,
+          triangles: 123_456,
+          textures: 41,
+          geometries: 80,
+          assetLoadTotalMs: 210,
+          fishUpdateAverageMs: 2.8,
+          waterMotionUpdateAverageMs: 1.8,
+          godRaysDepthRenderAverageMs: 4.6
+        }
+      }))
+    }
+    const browser = {
+      newPage: vi.fn(async () => page),
+      close: vi.fn()
+    }
+    const chromium = {
+      launch: vi.fn(async () => browser)
+    }
+
+    const result = await measureAquariumPerformance({
+      chromium,
+      fs: { writeFile },
+      url: 'http://127.0.0.1:5175/meaningless/',
+      durationMs: 30_000,
+      outputPath: '/tmp/perf.json'
+    })
+
+    expect(chromium.launch).toHaveBeenCalledWith({ headless: false })
+    expect(page.goto).toHaveBeenCalledWith(
+      'http://127.0.0.1:5175/meaningless/',
+      { waitUntil: 'domcontentloaded' }
+    )
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), 30_000)
+    expect(result.frameTime.p50Ms).toBe(18)
+    expect(result.frameTime.p95Ms).toBe(48)
+    expect(result.appStats.drawCalls).toBe(151)
+    expect(result.appStats.fishUpdateAverageMs).toBe(2.8)
+    expect(result.appStats.waterMotionUpdateAverageMs).toBe(1.8)
+    expect(result.appStats.godRaysDepthRenderAverageMs).toBe(4.6)
+    expect(writeFile).toHaveBeenCalledWith('/tmp/perf.json', `${JSON.stringify(result, null, 2)}\n`)
+    expect(browser.close).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/toolingDependencyHygiene.test.ts
+++ b/src/__tests__/toolingDependencyHygiene.test.ts
@@ -14,14 +14,17 @@ type PackageJson = {
 }
 
 describe('tooling dependency hygiene', () => {
-  it('keeps Playwright tied to the screenshot script instead of runtime code', () => {
+  it('keeps Playwright tied to local tooling scripts instead of runtime code', () => {
     const packageJson = readJson<PackageJson>('package.json')
     const screenshotScript = readText('scripts/capture-aquarium-screenshot.mjs')
+    const performanceScript = readText('scripts/measure-aquarium-performance.mjs')
 
     expect(packageJson.scripts?.screenshot).toBe('node scripts/capture-aquarium-screenshot.mjs')
+    expect(packageJson.scripts?.['measure:performance']).toBe('node scripts/measure-aquarium-performance.mjs')
     expect(packageJson.dependencies).not.toHaveProperty('playwright')
     expect(packageJson.devDependencies).toHaveProperty('playwright')
     expect(screenshotScript).toContain("from 'playwright'")
+    expect(performanceScript).toContain("from 'playwright'")
   })
 
   it('keeps Three runtime and type dependencies explicit', () => {

--- a/src/__tests__/viteConfig.test.ts
+++ b/src/__tests__/viteConfig.test.ts
@@ -3,15 +3,24 @@ import { describe, expect, it } from 'vitest'
 import config from '../../vite.config'
 
 describe('vite build chunking', () => {
-  it('splits three addons away from the core runtime chunk', () => {
-    const output = config.build?.rollupOptions?.output
-    const manualChunks = Array.isArray(output) ? undefined : output?.manualChunks
+  it('splits three examples addons by runtime concern', () => {
+    const output = config.build?.rolldownOptions?.output
+    const codeSplitting = Array.isArray(output) ? undefined : output?.codeSplitting
+    const firstGroup = typeof codeSplitting === 'object' ? codeSplitting.groups?.[0] : undefined
 
-    expect(typeof manualChunks).toBe('function')
+    expect(firstGroup).toBeDefined()
+    expect(codeSplitting).toMatchObject({
+      includeDependenciesRecursively: false,
+      maxSize: 450 * 1024
+    })
 
-    const resolveChunk = manualChunks as (id: string) => string | undefined
+    const resolveChunk = firstGroup?.name as (id: string) => string | null
     expect(resolveChunk('/workspace/node_modules/three/build/three.module.js')).toBe('three-core')
-    expect(resolveChunk('/workspace/node_modules/three/examples/jsm/postprocessing/EffectComposer.js')).toBe('three-addons')
-    expect(resolveChunk('/workspace/src/main.ts')).toBeUndefined()
+    expect(resolveChunk('/workspace/node_modules/.vite/deps/three.module-Dhi4sXJn.js')).toBe('three-core')
+    expect(resolveChunk('/workspace/node_modules/three/examples/jsm/postprocessing/EffectComposer.js')).toBe('three-postprocessing')
+    expect(resolveChunk('/workspace/node_modules/three/examples/jsm/loaders/GLTFLoader.js')).toBe('three-loaders')
+    expect(resolveChunk('/workspace/node_modules/three/examples/jsm/utils/SkeletonUtils.js')).toBe('three-utils')
+    expect(resolveChunk('/workspace/node_modules/three/examples/jsm/controls/OrbitControls.js')).toBe('three-controls')
+    expect(resolveChunk('/workspace/src/main.ts')).toBeNull()
   })
 })

--- a/src/assets/visualAssets.test.ts
+++ b/src/assets/visualAssets.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs'
 import * as THREE from 'three'
 import {
   createAquariumAssetManifest,
+  createBootAquariumAssetManifest,
+  createDeferredAquariumAssetManifest,
   loadVisualAssets,
   resolvePublicAssetUrl,
   type AssetManifest
@@ -46,6 +48,16 @@ const createImageTexture = (): THREE.Texture<HTMLImageElement> => new THREE.Text
 
 describe('loadVisualAssets', () => {
   it('loads textures, models, and hdri assets by id and falls back to null on failure', async () => {
+    let now = 100
+    const performanceMarks: string[] = []
+    const performanceMeasures: string[] = []
+    const performance = {
+      mark: (name: string) => performanceMarks.push(name),
+      measure: (name: string, startMark: string, endMark: string) => {
+        performanceMeasures.push(`${name}:${startMark}:${endMark}`)
+      },
+      clearMarks: () => undefined
+    }
     const textureLoader = {
       loadAsync: vi.fn(async (url: string) => {
         if (url.includes('missing')) {
@@ -86,7 +98,16 @@ describe('loadVisualAssets', () => {
       ]
     }
 
-    const assets = await loadVisualAssets(manifest, { textureLoader, gltfLoader, hdriLoader })
+    const assets = await loadVisualAssets(manifest, {
+      textureLoader,
+      gltfLoader,
+      hdriLoader,
+      now: () => {
+        now += 5
+        return now
+      },
+      performance
+    })
 
     expect(textureLoader.loadAsync).toHaveBeenCalledTimes(2)
     expect(gltfLoader.loadAsync).toHaveBeenCalledTimes(2)
@@ -97,6 +118,24 @@ describe('loadVisualAssets', () => {
     expect(assets.models['missing-model']).toBeNull()
     expect(assets.environment['aquarium-hdri']).toBeInstanceOf(THREE.Texture)
     expect(assets.environment['missing-hdri']).toBeNull()
+    expect(assets.loadTimings).toEqual(expect.objectContaining({
+      totalMs: expect.any(Number),
+      texturesMs: expect.any(Number),
+      modelsMs: expect.any(Number),
+      environmentMs: expect.any(Number)
+    }))
+    expect(performanceMarks).toContain('aquarium:assets:textures:start')
+    expect(performanceMarks).toContain('aquarium:assets:models:start')
+    expect(performanceMarks).toContain('aquarium:assets:environment:start')
+    expect(performanceMeasures).toContain(
+      'aquarium:assets:textures:aquarium:assets:textures:start:aquarium:assets:textures:end'
+    )
+    expect(performanceMeasures).toContain(
+      'aquarium:assets:models:aquarium:assets:models:start:aquarium:assets:models:end'
+    )
+    expect(performanceMeasures).toContain(
+      'aquarium:assets:environment:aquarium:assets:environment:start:aquarium:assets:environment:end'
+    )
   })
 
   it('treats invalid school models as unavailable so instancing can fall back safely', async () => {
@@ -218,6 +257,31 @@ describe('loadVisualAssets', () => {
 })
 
 describe('public aquarium asset urls', () => {
+  it('splits startup-critical assets from deferred optional fish assets', () => {
+    const bootManifest = createBootAquariumAssetManifest('/')
+    const deferredManifest = createDeferredAquariumAssetManifest('/')
+    const bootTextureIds = new Set(bootManifest.textures.map((entry) => entry.id))
+    const bootModelIds = new Set(bootManifest.models.map((entry) => entry.id))
+    const deferredTextureIds = new Set(deferredManifest.textures.map((entry) => entry.id))
+    const deferredModelIds = new Set(deferredManifest.models.map((entry) => entry.id))
+
+    expect(bootTextureIds.has('leaf-diffuse')).toBe(true)
+    expect(bootTextureIds.has('substrate-sand-normal')).toBe(true)
+    expect(bootTextureIds.has('fish-neon-basecolor')).toBe(true)
+    expect(bootTextureIds.has('fish-goldfish-basecolor')).toBe(false)
+    expect(bootModelIds.has('plant-amazon-sword')).toBe(true)
+    expect(bootModelIds.has('driftwood-hero')).toBe(true)
+    expect(bootModelIds.has('fish-neon-school')).toBe(true)
+    expect(bootModelIds.has('fish-goldfish-hero')).toBe(false)
+
+    expect(deferredTextureIds.has('fish-goldfish-basecolor')).toBe(true)
+    expect(deferredTextureIds.has('fish-neon-basecolor')).toBe(false)
+    expect(deferredModelIds.has('fish-goldfish-hero')).toBe(true)
+    expect(deferredModelIds.has('plant-amazon-sword')).toBe(false)
+    expect(bootManifest.environment).toHaveLength(1)
+    expect(deferredManifest.environment).toHaveLength(0)
+  })
+
   it('uses authored fish texture atlases instead of fish SVG diffuse assets', () => {
     const manifest = createAquariumAssetManifest('/')
     const textureIds = new Set(manifest.textures.map((entry) => entry.id))

--- a/src/assets/visualAssets.ts
+++ b/src/assets/visualAssets.ts
@@ -8,6 +8,7 @@ import {
   modelAssetPath,
   textureAssetPath
 } from './assetPathConventions.js'
+import type { AssetLoadTimingStats, PerformanceLike } from '../utils/performanceStats'
 
 export type AssetUsageTag =
   | 'plant'
@@ -60,6 +61,7 @@ export type VisualAssetBundle = {
   textures: Record<string, THREE.Texture | null>
   models: Record<string, LoadedModelAsset | null>
   environment: Record<string, THREE.Texture | null>
+  loadTimings?: AssetLoadTimingStats
 }
 
 type TextureLoaderLike = Pick<THREE.TextureLoader, 'loadAsync'>
@@ -67,6 +69,7 @@ type GLTFLoaderLike = {
   loadAsync(url: string): Promise<{ scene: THREE.Object3D | THREE.Group; animations?: THREE.AnimationClip[] }>
 }
 type HDRILoaderLike = Pick<RGBELoader, 'loadAsync'>
+type AssetLoadClock = () => number
 
 const materialTextureKeys = [
   'map',
@@ -195,6 +198,25 @@ const loadModelAsset = async (
   }
 }
 
+const measureAssetLoad = async <T>(
+  now: AssetLoadClock,
+  performanceLike: PerformanceLike | undefined,
+  label: string,
+  load: () => Promise<T>
+): Promise<[T, number]> => {
+  const startMark = `aquarium:assets:${label}:start`
+  const endMark = `aquarium:assets:${label}:end`
+  performanceLike?.mark?.(startMark)
+  const start = now()
+  const result = await load()
+  const duration = Math.max(0, now() - start)
+  performanceLike?.mark?.(endMark)
+  performanceLike?.measure?.(`aquarium:assets:${label}`, startMark, endMark)
+  performanceLike?.clearMarks?.(startMark)
+  performanceLike?.clearMarks?.(endMark)
+  return [result, duration]
+}
+
 export const resolvePublicAssetUrl = (
   assetPath: string,
   baseUrl: string = import.meta.env.BASE_URL ?? '/'
@@ -283,6 +305,50 @@ export const createAquariumAssetManifest = (
   ]
 })
 
+const bootFishTextureIds = new Set([
+  'fish-neon-basecolor',
+  'fish-neon-normal',
+  'fish-neon-roughness',
+  'fish-neon-alpha',
+  'fish-scale-normal',
+  'fish-scale-roughness'
+])
+
+const bootFishModelIds = new Set([
+  'fish-neon-school',
+  'fish-neon-hero'
+])
+
+const isBootTextureEntry = (entry: ManifestTextureEntry): boolean => (
+  entry.usageTag !== 'fish' || bootFishTextureIds.has(entry.id)
+)
+
+const isBootModelEntry = (entry: ManifestModelEntry): boolean => (
+  entry.usageTag !== 'fish' || bootFishModelIds.has(entry.id)
+)
+
+export const createBootAquariumAssetManifest = (
+  baseUrl: string = import.meta.env.BASE_URL ?? '/'
+): AssetManifest => {
+  const manifest = createAquariumAssetManifest(baseUrl)
+  return {
+    textures: manifest.textures.filter(isBootTextureEntry),
+    models: manifest.models.filter(isBootModelEntry),
+    environment: manifest.environment
+  }
+}
+
+export const createDeferredAquariumAssetManifest = (
+  baseUrl: string = import.meta.env.BASE_URL ?? '/'
+): AssetManifest => {
+  const manifest = createAquariumAssetManifest(baseUrl)
+  return {
+    textures: manifest.textures.filter((entry) => !isBootTextureEntry(entry)),
+    models: manifest.models.filter((entry) => !isBootModelEntry(entry)),
+    environment: []
+  }
+}
+
 export const aquariumAssetManifest: AssetManifest = createAquariumAssetManifest()
 
 export const loadVisualAssets = async (
@@ -291,38 +357,62 @@ export const loadVisualAssets = async (
     textureLoader?: TextureLoaderLike
     gltfLoader?: GLTFLoaderLike
     hdriLoader?: HDRILoaderLike
+    now?: AssetLoadClock
+    performance?: PerformanceLike
   } = {}
 ): Promise<VisualAssetBundle> => {
   const textureLoader = options.textureLoader ?? new THREE.TextureLoader()
   const gltfLoader = options.gltfLoader ?? new GLTFLoader()
   const hdriLoader = options.hdriLoader ?? new RGBELoader()
+  const now = options.now ?? (() => performance.now())
+  const performanceLike = options.performance ?? (typeof performance === 'undefined' ? undefined : performance)
 
-  const [textureEntries, modelEntries, environmentEntries] = await Promise.all([
-    Promise.all(
-      manifest.textures.map(async (entry) => {
-        try {
-          const texture = await textureLoader.loadAsync(entry.url)
-          return [entry.id, configureTexture(texture, entry)] as const
-        } catch {
-          return [entry.id, null] as const
-        }
-      })
+  const totalStart = now()
+  const [
+    [textureEntries, texturesMs],
+    [modelEntries, modelsMs],
+    [environmentEntries, environmentMs]
+  ] = await Promise.all([
+    measureAssetLoad(
+      now,
+      performanceLike,
+      'textures',
+      () => Promise.all(
+        manifest.textures.map(async (entry) => {
+          try {
+            const texture = await textureLoader.loadAsync(entry.url)
+            return [entry.id, configureTexture(texture, entry)] as const
+          } catch {
+            return [entry.id, null] as const
+          }
+        })
+      )
     ),
-    Promise.all(
-      manifest.models.map(async (entry) => {
-        const model = await loadModelAsset(entry, gltfLoader)
-        return [entry.id, model] as const
-      })
+    measureAssetLoad(
+      now,
+      performanceLike,
+      'models',
+      () => Promise.all(
+        manifest.models.map(async (entry) => {
+          const model = await loadModelAsset(entry, gltfLoader)
+          return [entry.id, model] as const
+        })
+      )
     ),
-    Promise.all(
-      manifest.environment.map(async (entry) => {
-        try {
-          const texture = await hdriLoader.loadAsync(entry.url)
-          return [entry.id, configureEnvironmentTexture(texture)] as const
-        } catch {
-          return [entry.id, null] as const
-        }
-      })
+    measureAssetLoad(
+      now,
+      performanceLike,
+      'environment',
+      () => Promise.all(
+        manifest.environment.map(async (entry) => {
+          try {
+            const texture = await hdriLoader.loadAsync(entry.url)
+            return [entry.id, configureEnvironmentTexture(texture)] as const
+          } catch {
+            return [entry.id, null] as const
+          }
+        })
+      )
     )
   ])
 
@@ -330,6 +420,12 @@ export const loadVisualAssets = async (
     manifest,
     textures: Object.fromEntries(textureEntries),
     models: Object.fromEntries(modelEntries),
-    environment: Object.fromEntries(environmentEntries)
+    environment: Object.fromEntries(environmentEntries),
+    loadTimings: {
+      totalMs: Math.max(0, now() - totalStart),
+      texturesMs,
+      modelsMs,
+      environmentMs
+    }
   }
 }

--- a/src/components/AdvancedScene.test.ts
+++ b/src/components/AdvancedScene.test.ts
@@ -13,6 +13,7 @@ import {
   resolvePhotoModeControlsTarget
 } from '../utils/aquariumLayout'
 import type { Theme } from '../types/aquarium'
+import { defaultTheme } from '../utils/stateSchema'
 
 type CreateSubstrateFn = (dimensions: AquariumTankDimensions) => void
 
@@ -310,6 +311,267 @@ describe('AdvancedAquariumScene performance stats', () => {
 
     expect(internals.stats.fishVisible).toBe(24)
   })
+
+  it('copies god ray depth render timing into scene performance stats', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      godRaysEffect: { getDepthRenderStats: () => { count: number; lastMs: number; averageMs: number } } | null
+      stats: {
+        godRaysDepthRenderCount: number
+        godRaysDepthRenderLastMs: number
+        godRaysDepthRenderAverageMs: number
+      }
+    }
+
+    internals.godRaysEffect = {
+      getDepthRenderStats: () => ({
+        count: 3,
+        lastMs: 4.5,
+        averageMs: 5.25
+      })
+    }
+    internals.stats = {
+      godRaysDepthRenderCount: 0,
+      godRaysDepthRenderLastMs: 0,
+      godRaysDepthRenderAverageMs: 0
+    }
+
+    const syncGodRaysDepthRenderStats = (AdvancedAquariumScene.prototype as unknown as {
+      syncGodRaysDepthRenderStats: () => void
+    }).syncGodRaysDepthRenderStats.bind(instance)
+
+    syncGodRaysDepthRenderStats()
+
+    expect(internals.stats).toEqual({
+      godRaysDepthRenderCount: 3,
+      godRaysDepthRenderLastMs: 4.5,
+      godRaysDepthRenderAverageMs: 5.25
+    })
+  })
+
+  it('lowers standard quality render scale after sustained high frame times', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      renderer: { setPixelRatio: (value: number) => void }
+      currentVisualQuality: 'standard'
+      adaptiveRenderScale: number
+      stressedFrameSamples: number
+      stableFrameSamples: number
+    }
+    internals.renderer = { setPixelRatio: vi.fn() }
+    internals.currentVisualQuality = 'standard'
+    internals.adaptiveRenderScale = 1
+    internals.stressedFrameSamples = 2
+    internals.stableFrameSamples = 0
+
+    const syncAdaptiveRenderScale = (AdvancedAquariumScene.prototype as unknown as {
+      syncAdaptiveRenderScale: (frameTimeMs: number) => void
+    }).syncAdaptiveRenderScale.bind(instance)
+
+    const originalDevicePixelRatio = window.devicePixelRatio
+    Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2 })
+    try {
+      syncAdaptiveRenderScale(36)
+    } finally {
+      Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: originalDevicePixelRatio })
+    }
+
+    expect(internals.adaptiveRenderScale).toBe(0.85)
+    expect(internals.renderer.setPixelRatio).toHaveBeenCalledWith(1.7)
+  })
+})
+
+describe('AdvancedAquariumScene measurement tuning', () => {
+  it('applies an explicit shadow map size override for A/B measurement', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      performanceTuning: { shadowMapSize: number | null }
+      primaryShadowLight: {
+        shadow: {
+          mapSize: { width: number; height: number }
+        }
+      }
+    }
+    internals.performanceTuning = { shadowMapSize: 1024 }
+    internals.primaryShadowLight = {
+      shadow: {
+        mapSize: { width: 0, height: 0 }
+      }
+    }
+
+    const applyShadowQuality = (AdvancedAquariumScene.prototype as unknown as {
+      applyShadowQuality: (quality: 'simple' | 'standard') => void
+    }).applyShadowQuality.bind(instance)
+
+    applyShadowQuality('standard')
+
+    expect(internals.primaryShadowLight.shadow.mapSize).toEqual({
+      width: 1024,
+      height: 1024
+    })
+  })
+
+  it('uses leaner default shadow maps for standard and simple quality', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      performanceTuning: { shadowMapSize: number | null }
+      primaryShadowLight: {
+        shadow: {
+          mapSize: { width: number; height: number }
+        }
+      }
+    }
+    internals.performanceTuning = { shadowMapSize: null }
+    internals.primaryShadowLight = {
+      shadow: {
+        mapSize: { width: 0, height: 0 }
+      }
+    }
+
+    const applyShadowQuality = (AdvancedAquariumScene.prototype as unknown as {
+      applyShadowQuality: (quality: 'simple' | 'standard') => void
+    }).applyShadowQuality.bind(instance)
+
+    applyShadowQuality('standard')
+
+    expect(internals.primaryShadowLight.shadow.mapSize).toEqual({
+      width: 2048,
+      height: 2048
+    })
+
+    applyShadowQuality('simple')
+
+    expect(internals.primaryShadowLight.shadow.mapSize).toEqual({
+      width: 1024,
+      height: 1024
+    })
+  })
+
+  it('disables screen-space haze passes for A/B measurement', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const godRaysEffect = { setScreenSpaceWaterHazeEnabled: vi.fn() }
+    const internals = instance as unknown as {
+      camera: { aspect: number }
+      currentVisualQuality: 'standard'
+      performanceTuning: { screenSpaceHazeEnabled: boolean }
+      screenSpaceHazePass: { enabled: boolean; uniforms: { aspect: { value: number } } }
+      godRaysEffect: typeof godRaysEffect
+    }
+    internals.camera = { aspect: 1.5 }
+    internals.currentVisualQuality = 'standard'
+    internals.performanceTuning = { screenSpaceHazeEnabled: false }
+    internals.screenSpaceHazePass = {
+      enabled: true,
+      uniforms: { aspect: { value: 1.5 } }
+    }
+    internals.godRaysEffect = godRaysEffect
+
+    const syncScreenSpaceHazePass = (AdvancedAquariumScene.prototype as unknown as {
+      syncScreenSpaceHazePass: (theme: typeof defaultTheme) => void
+    }).syncScreenSpaceHazePass.bind(instance)
+
+    syncScreenSpaceHazePass(defaultTheme)
+
+    expect(internals.screenSpaceHazePass.enabled).toBe(false)
+    expect(godRaysEffect.setScreenSpaceWaterHazeEnabled).toHaveBeenCalledWith(false)
+  })
+
+  it('renders directly when post-processing is disabled for A/B measurement', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const godRaysEffect = { update: vi.fn(), render: vi.fn() }
+    const composer = { render: vi.fn() }
+    const renderer = { render: vi.fn() }
+    const internals = instance as unknown as {
+      performanceTuning: { postProcessingEnabled: boolean }
+      godRaysEffect: typeof godRaysEffect
+      composer: typeof composer
+      renderer: typeof renderer
+      scene: unknown
+      camera: unknown
+      advancedEffectsEnabled: boolean
+      motionScale: number
+    }
+    internals.performanceTuning = { postProcessingEnabled: false }
+    internals.godRaysEffect = godRaysEffect
+    internals.composer = composer
+    internals.renderer = renderer
+    internals.scene = {}
+    internals.camera = {}
+    internals.advancedEffectsEnabled = true
+    internals.motionScale = 1
+
+    const renderSceneFrame = (AdvancedAquariumScene.prototype as unknown as {
+      renderSceneFrame: (elapsedTime: number) => void
+    }).renderSceneFrame.bind(instance)
+
+    renderSceneFrame(12)
+
+    expect(renderer.render).toHaveBeenCalledWith(internals.scene, internals.camera)
+    expect(godRaysEffect.render).not.toHaveBeenCalled()
+    expect(composer.render).not.toHaveBeenCalled()
+  })
+
+  it('renders directly on simple quality to avoid God rays post-processing cost', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const godRaysEffect = { update: vi.fn(), render: vi.fn() }
+    const composer = { render: vi.fn() }
+    const renderer = { render: vi.fn() }
+    const internals = instance as unknown as {
+      performanceTuning: { postProcessingEnabled: boolean }
+      currentVisualQuality: 'simple'
+      godRaysEffect: typeof godRaysEffect
+      composer: typeof composer
+      renderer: typeof renderer
+      scene: unknown
+      camera: unknown
+      advancedEffectsEnabled: boolean
+      motionScale: number
+    }
+    internals.performanceTuning = { postProcessingEnabled: true }
+    internals.currentVisualQuality = 'simple'
+    internals.godRaysEffect = godRaysEffect
+    internals.composer = composer
+    internals.renderer = renderer
+    internals.scene = {}
+    internals.camera = {}
+    internals.advancedEffectsEnabled = true
+    internals.motionScale = 1
+
+    const renderSceneFrame = (AdvancedAquariumScene.prototype as unknown as {
+      renderSceneFrame: (elapsedTime: number) => void
+    }).renderSceneFrame.bind(instance)
+
+    renderSceneFrame(12)
+
+    expect(renderer.render).toHaveBeenCalledWith(internals.scene, internals.camera)
+    expect(godRaysEffect.update).not.toHaveBeenCalled()
+    expect(godRaysEffect.render).not.toHaveBeenCalled()
+    expect(composer.render).not.toHaveBeenCalled()
+  })
+
+  it('updates tank water motion every other frame on simple quality', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      currentVisualQuality: 'simple' | 'standard'
+      waterMotionFrame: number
+    }
+    internals.currentVisualQuality = 'simple'
+    internals.waterMotionFrame = 0
+
+    const shouldUpdateTankWaterMotion = (AdvancedAquariumScene.prototype as unknown as {
+      shouldUpdateTankWaterMotion: () => boolean
+    }).shouldUpdateTankWaterMotion.bind(instance)
+
+    expect(shouldUpdateTankWaterMotion()).toBe(true)
+    expect(shouldUpdateTankWaterMotion()).toBe(false)
+    expect(shouldUpdateTankWaterMotion()).toBe(true)
+
+    internals.currentVisualQuality = 'standard'
+    internals.waterMotionFrame = 0
+
+    expect(shouldUpdateTankWaterMotion()).toBe(true)
+    expect(shouldUpdateTankWaterMotion()).toBe(true)
+  })
 })
 
 describe('AdvancedAquariumScene camera', () => {
@@ -583,7 +845,7 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     expect((overlay?.material as THREE.MeshBasicMaterial | undefined)?.map).toBe(overlayTexture)
   })
 
-  it('builds visible glass and water layers around the tank volume', () => {
+  it('builds visible water layers around the tank volume without transparent glass panes', () => {
     const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
     const internals = instance as unknown as {
       tank: THREE.Group
@@ -601,16 +863,44 @@ describe('AdvancedAquariumScene tank backdrop', () => {
 
     createAdvancedTank()
 
-    const frontGlass = internals.tank.children.find((child) => child.name === 'tank-glass-front') as THREE.Mesh | undefined
     const waterVolume = internals.tank.children.find((child) => child.name === 'tank-water-volume') as THREE.Mesh | undefined
     const surface = internals.tank.children.find((child) => child.name === 'tank-water-surface') as THREE.Mesh | undefined
     const caustics = internals.tank.children.find((child) => child.name === 'tank-caustics-floor') as THREE.Mesh | undefined
+    const glassMeshes = internals.tank.children.filter((child) => child.name.startsWith('tank-glass-'))
 
-    expect(frontGlass).toBeDefined()
-    expect(frontGlass?.material).toBeInstanceOf(THREE.MeshPhysicalMaterial)
+    expect(glassMeshes).toHaveLength(0)
     expect(waterVolume).toBeDefined()
     expect(surface).toBeDefined()
     expect(caustics).toBeDefined()
+  })
+
+  it('does not create transparent glass pane or highlight meshes for the performance profile', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      tank: THREE.Group
+      createSubstrate: CreateSubstrateFn
+      createBackdropTexture: () => THREE.CanvasTexture
+      glassPanes: THREE.Mesh[]
+      frontGlassHighlightMesh: THREE.Mesh | null
+      glassEdgeHighlightMeshes: THREE.Mesh[]
+    }
+
+    internals.tank = new THREE.Group()
+    internals.createSubstrate = vi.fn()
+    internals.createBackdropTexture = () => new THREE.CanvasTexture(document.createElement('canvas'))
+
+    const createAdvancedTank = (AdvancedAquariumScene.prototype as unknown as {
+      createAdvancedTank: () => void
+    }).createAdvancedTank.bind(instance)
+
+    createAdvancedTank()
+
+    const glassMeshes = internals.tank.children.filter((child) => child.name.startsWith('tank-glass-'))
+
+    expect(glassMeshes).toHaveLength(0)
+    expect(internals.glassPanes).toEqual([])
+    expect(internals.glassEdgeHighlightMeshes).toEqual([])
+    expect(internals.frontGlassHighlightMesh).toBeNull()
   })
 
   it('suppresses box-like wall and water-volume planes for nature-showcase so the view reads as open water', () => {
@@ -658,9 +948,7 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     )
 
     expect(wallPanels.every((mesh) => mesh === undefined)).toBe(true)
-    sideGlass.forEach((mesh) => {
-      expect((mesh?.material as THREE.MeshPhysicalMaterial | undefined)?.opacity).toBeLessThanOrEqual(0.018)
-    })
+    expect(sideGlass.every((mesh) => mesh === undefined)).toBe(true)
     expect(waterVolume?.geometry).not.toBeInstanceOf(THREE.BoxGeometry)
     expect((waterVolume?.material as THREE.Material | undefined)?.transparent).toBe(true)
     depthLayers.forEach((mesh) => {
@@ -713,15 +1001,11 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     const foreground = internals.tank.children.find((child) => child.name === 'tank-depth-foreground-shadow') as THREE.Mesh | undefined
     const frontHighlight = internals.tank.children.find((child) => child.name === 'tank-glass-front-highlight') as THREE.Mesh | undefined
 
-    sideAndBackGlass.forEach((mesh) => {
-      expect(mesh?.visible).toBe(false)
-    })
-    edgeHighlights.forEach((mesh) => {
-      expect(mesh?.visible).toBe(false)
-    })
+    expect(sideAndBackGlass.every((mesh) => mesh === undefined)).toBe(true)
+    expect(edgeHighlights.every((mesh) => mesh === undefined)).toBe(true)
     expect((waterVolume?.material as THREE.MeshPhysicalMaterial | undefined)?.opacity).toBeLessThanOrEqual(0.006)
     expect((foreground?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThanOrEqual(0.004)
-    expect((frontHighlight?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThanOrEqual(0.012)
+    expect(frontHighlight).toBeUndefined()
   })
 
   it('does not add a screen-space water haze pass to the composer', () => {
@@ -782,7 +1066,7 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     expect(edgeBlends.every((mesh) => mesh === undefined)).toBe(true)
   })
 
-  it('adds premium highlight layers and richer refractive materials on high quality', () => {
+  it('adds premium water highlight layers and richer refractive water materials on high quality', () => {
     const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
     const internals = instance as unknown as {
       tank: THREE.Group
@@ -800,25 +1084,20 @@ describe('AdvancedAquariumScene tank backdrop', () => {
 
     createAdvancedTank()
 
-    const frontGlass = internals.tank.children.find((child) => child.name === 'tank-glass-front') as THREE.Mesh | undefined
-    const frontHighlight = internals.tank.children.find((child) => child.name === 'tank-glass-front-highlight') as THREE.Mesh | undefined
     const waterVolume = internals.tank.children.find((child) => child.name === 'tank-water-volume') as THREE.Mesh | undefined
     const surface = internals.tank.children.find((child) => child.name === 'tank-water-surface') as THREE.Mesh | undefined
     const surfaceHighlight = internals.tank.children.find((child) => child.name === 'tank-water-surface-highlight') as THREE.Mesh | undefined
 
-    const frontGlassMaterial = frontGlass?.material as THREE.MeshPhysicalMaterial | undefined
     const waterVolumeMaterial = waterVolume?.material as THREE.MeshPhysicalMaterial | undefined
     const surfaceMaterial = surface?.material as THREE.MeshPhysicalMaterial | undefined
 
-    expect(frontHighlight).toBeDefined()
     expect(surfaceHighlight).toBeDefined()
-    expect(frontGlassMaterial?.attenuationDistance).toBeLessThan(2)
     expect(waterVolumeMaterial?.attenuationDistance).toBeLessThan(3)
     expect(surfaceMaterial?.thickness).toBeGreaterThan(0.8)
     expect(surfaceMaterial?.attenuationDistance).toBeLessThan(2)
   })
 
-  it('adds a waterline rim and edge glints so the tank reads as layered glass and water', () => {
+  it('adds a waterline rim without glass pane edge glints', () => {
     const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
     const internals = instance as unknown as {
       tank: THREE.Group
@@ -836,19 +1115,14 @@ describe('AdvancedAquariumScene tank backdrop', () => {
 
     createAdvancedTank()
 
-    const frontHighlight = internals.tank.children.find((child) => child.name === 'tank-glass-front-highlight') as THREE.Mesh | undefined
     const leftEdgeHighlight = internals.tank.children.find((child) => child.name === 'tank-glass-edge-highlight-left') as THREE.Mesh | undefined
     const rightEdgeHighlight = internals.tank.children.find((child) => child.name === 'tank-glass-edge-highlight-right') as THREE.Mesh | undefined
     const waterlineFront = internals.tank.children.find((child) => child.name === 'tank-waterline-front') as THREE.Mesh | undefined
 
-    const frontHighlightMaterial = frontHighlight?.material as THREE.MeshBasicMaterial | undefined
-    expect(leftEdgeHighlight).toBeDefined()
-    expect(rightEdgeHighlight).toBeDefined()
+    expect(leftEdgeHighlight).toBeUndefined()
+    expect(rightEdgeHighlight).toBeUndefined()
     expect(waterlineFront).toBeDefined()
-    expect(leftEdgeHighlight?.position.z).toBeCloseTo((AQUARIUM_TANK_DIMENSIONS.depth / 2) + 0.076)
-    expect(rightEdgeHighlight?.position.x).toBeCloseTo((AQUARIUM_TANK_DIMENSIONS.width / 2) - 0.12)
     expect((waterlineFront?.material as THREE.MeshBasicMaterial | undefined)?.blending).toBe(THREE.AdditiveBlending)
-    expect(frontHighlightMaterial?.opacity).toBeLessThan(0.11)
     expect((waterlineFront?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThan(0.11)
     expect((waterlineFront?.geometry as THREE.PlaneGeometry).parameters.height).toBeGreaterThan(0.54)
   })
@@ -1124,7 +1398,7 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     expect(canopyMaterial?.opacity).toBeGreaterThan(0.145)
   })
 
-  it('splits underwater lighting into wide near-surface bands, layered midwater scatter, and phase-linked caustics', () => {
+  it('layers baked near-surface light, midwater scatter, and phase-linked caustics', () => {
     const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
     const internals = instance as unknown as {
       tank: THREE.Group
@@ -1142,8 +1416,8 @@ describe('AdvancedAquariumScene tank backdrop', () => {
 
     createAdvancedTank()
 
-    const nearSurfaceBands = internals.tank.children.filter((child) => (
-      child.name.startsWith('tank-light-near-surface-band-')
+    const nearSurfaceSheets = internals.tank.children.filter((child) => (
+      child.name.startsWith('tank-light-near-surface-')
     )) as THREE.Mesh[]
     const midwaterLayers = internals.tank.children.filter((child) => (
       child.name.startsWith('tank-light-midwater-')
@@ -1152,32 +1426,21 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     const substrateGlow = internals.tank.children.find((child) => child.name === 'tank-hero-ground-glow') as THREE.Mesh | undefined
     const backCaustics = internals.tank.children.find((child) => child.name === 'tank-caustics-back') as THREE.Mesh | undefined
 
-    expect(nearSurfaceBands).toHaveLength(5)
-    expect(nearSurfaceBands.map((mesh) => mesh.name)).toEqual([
-      'tank-light-near-surface-band-0',
-      'tank-light-near-surface-band-1',
-      'tank-light-near-surface-band-2',
-      'tank-light-near-surface-band-3',
-      'tank-light-near-surface-band-4'
-    ])
-    expect(nearSurfaceBands.every((mesh) => (
+    expect(nearSurfaceSheets.map((mesh) => mesh.name)).toEqual(['tank-light-near-surface-sheet'])
+    expect(nearSurfaceSheets.every((mesh) => (
       getTopClearanceRatio(mesh.position, AQUARIUM_TANK_DIMENSIONS) > 0.18 &&
       getTopClearanceRatio(mesh.position, AQUARIUM_TANK_DIMENSIONS) < 0.22
     ))).toBe(true)
-    expect(getWidthRatio(nearSurfaceBands[0].position, AQUARIUM_TANK_DIMENSIONS)).toBeLessThan(-0.28)
-    expect(getWidthRatio(nearSurfaceBands[4].position, AQUARIUM_TANK_DIMENSIONS)).toBeGreaterThan(0.28)
-    expect(midwaterLayers.map((mesh) => mesh.name)).toEqual([
-      'tank-light-midwater-fill',
-      'tank-light-midwater-breakup'
-    ])
-    expect(midwaterLayers).toHaveLength(2)
-    expect((midwaterLayers[0].material as THREE.MeshBasicMaterial | undefined)?.blending).toBe(THREE.AdditiveBlending)
-    expect((midwaterLayers[1].material as THREE.MeshBasicMaterial | undefined)?.blending).toBe(THREE.AdditiveBlending)
-    expect((midwaterLayers[0].geometry as THREE.PlaneGeometry).parameters.width).toBeGreaterThan(
-      (midwaterLayers[1].geometry as THREE.PlaneGeometry).parameters.width
+    expect(getWidthRatio(nearSurfaceSheets[0].position, AQUARIUM_TANK_DIMENSIONS)).toBeGreaterThan(0.01)
+    expect(getWidthRatio(nearSurfaceSheets[0].position, AQUARIUM_TANK_DIMENSIONS)).toBeLessThan(0.025)
+    expect((nearSurfaceSheets[0].geometry as THREE.PlaneGeometry).parameters.width).toBeGreaterThan(
+      AQUARIUM_TANK_DIMENSIONS.width * 1.4
     )
-    expect((midwaterLayers[0].material as THREE.MeshBasicMaterial).opacity).toBeLessThan(
-      (midwaterLayers[1].material as THREE.MeshBasicMaterial).opacity
+    expect(midwaterLayers.map((mesh) => mesh.name)).toEqual(['tank-light-midwater-sheet'])
+    expect(midwaterLayers).toHaveLength(1)
+    expect((midwaterLayers[0].material as THREE.MeshBasicMaterial | undefined)?.blending).toBe(THREE.AdditiveBlending)
+    expect((midwaterLayers[0].geometry as THREE.PlaneGeometry).parameters.width).toBeGreaterThan(
+      AQUARIUM_TANK_DIMENSIONS.width * 0.8
     )
     expect(getBottomClearanceRatio(substrateGlow!.position, AQUARIUM_TANK_DIMENSIONS)).toBeGreaterThan(0.055)
     expect(getBottomClearanceRatio(substrateGlow!.position, AQUARIUM_TANK_DIMENSIONS)).toBeLessThan(0.062)
@@ -1185,12 +1448,72 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     expect(getWidthRatio(backCaustics!.position, AQUARIUM_TANK_DIMENSIONS)).toBeGreaterThan(0.06)
     expect(getWidthRatio(backCaustics!.position, AQUARIUM_TANK_DIMENSIONS)).toBeLessThan(0.1)
     expect(getDepthRatio(backCaustics!.position, AQUARIUM_TANK_DIMENSIONS)).toBeLessThan(-0.4)
-    expect(nearSurfaceBands.every((mesh) => mesh.userData.phaseFamily === 'surface-caustic')).toBe(true)
+    expect(nearSurfaceSheets.every((mesh) => mesh.userData.phaseFamily === 'surface-caustic')).toBe(true)
     expect(midwaterLayers.every((mesh) => mesh.userData.phaseFamily === 'surface-caustic')).toBe(true)
     expect(floorCaustics?.userData.phaseFamily).toBe('surface-caustic')
     expect(backCaustics?.userData.phaseFamily).toBe('surface-caustic')
     expect((floorCaustics?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThan(0.055)
     expect((backCaustics?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThan(0.04)
+  })
+
+  it('bakes near-surface light bands into one transparent sheet for fewer draw calls', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      tank: THREE.Group
+      createSubstrate: CreateSubstrateFn
+      createBackdropTexture: () => THREE.CanvasTexture
+      nearSurfaceLightMeshes: THREE.Mesh[]
+    }
+
+    internals.tank = new THREE.Group()
+    internals.createSubstrate = vi.fn()
+    internals.createBackdropTexture = () => new THREE.CanvasTexture(document.createElement('canvas'))
+
+    const createAdvancedTank = (AdvancedAquariumScene.prototype as unknown as {
+      createAdvancedTank: () => void
+    }).createAdvancedTank.bind(instance)
+
+    createAdvancedTank()
+
+    const nearSurfaceSheets = internals.tank.children.filter((child) => (
+      child.name.startsWith('tank-light-near-surface-')
+    )) as THREE.Mesh[]
+
+    expect(nearSurfaceSheets.map((mesh) => mesh.name)).toEqual(['tank-light-near-surface-sheet'])
+    expect(internals.nearSurfaceLightMeshes).toHaveLength(1)
+    expect((nearSurfaceSheets[0].geometry as THREE.PlaneGeometry).parameters.width).toBeGreaterThan(
+      AQUARIUM_TANK_DIMENSIONS.width * 1.4
+    )
+    expect(nearSurfaceSheets[0].userData.phaseFamily).toBe('surface-caustic')
+  })
+
+  it('bakes midwater light fill and breakup into one transparent sheet for fewer draw calls', () => {
+    const instance = Object.create(AdvancedAquariumScene.prototype) as AdvancedAquariumScene
+    const internals = instance as unknown as {
+      tank: THREE.Group
+      createSubstrate: CreateSubstrateFn
+      createBackdropTexture: () => THREE.CanvasTexture
+      midwaterLightMeshes: THREE.Mesh[]
+    }
+
+    internals.tank = new THREE.Group()
+    internals.createSubstrate = vi.fn()
+    internals.createBackdropTexture = () => new THREE.CanvasTexture(document.createElement('canvas'))
+
+    const createAdvancedTank = (AdvancedAquariumScene.prototype as unknown as {
+      createAdvancedTank: () => void
+    }).createAdvancedTank.bind(instance)
+
+    createAdvancedTank()
+
+    const midwaterSheets = internals.tank.children.filter((child) => (
+      child.name.startsWith('tank-light-midwater-')
+    )) as THREE.Mesh[]
+
+    expect(midwaterSheets.map((mesh) => mesh.name)).toEqual(['tank-light-midwater-sheet'])
+    expect(internals.midwaterLightMeshes).toHaveLength(1)
+    expect(midwaterSheets[0].userData.midwaterLayer).toBe('combined')
+    expect(midwaterSheets[0].userData.phaseFamily).toBe('surface-caustic')
   })
 
   it('keeps hero lighting anchors tank-relative when the tank dimensions grow', () => {
@@ -1213,39 +1536,38 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     createAdvancedTank()
 
     const lightCanopy = internals.tank.children.find((child) => child.name === 'tank-light-canopy') as THREE.Mesh | undefined
-    const nearSurfaceBands = internals.tank.children.filter((child) => (
-      child.name.startsWith('tank-light-near-surface-band-')
+    const nearSurfaceSheets = internals.tank.children.filter((child) => (
+      child.name.startsWith('tank-light-near-surface-')
     )) as THREE.Mesh[]
     const midwaterLayers = internals.tank.children.filter((child) => (
       child.name.startsWith('tank-light-midwater-')
     )) as THREE.Mesh[]
-    const midwaterFill = midwaterLayers.find((child) => child.name === 'tank-light-midwater-fill')
+    const midwaterSheet = midwaterLayers.find((child) => child.name === 'tank-light-midwater-sheet')
     const heroRimLight = internals.tank.children.find((child) => child.name === 'tank-hero-rim-light') as THREE.Mesh | undefined
     const heroGroundGlow = internals.tank.children.find((child) => child.name === 'tank-hero-ground-glow') as THREE.Mesh | undefined
 
     expect(lightCanopy).toBeDefined()
-    expect(nearSurfaceBands).toHaveLength(5)
-    expect(midwaterLayers).toHaveLength(2)
-    expect(midwaterFill).toBeDefined()
+    expect(nearSurfaceSheets).toHaveLength(1)
+    expect(midwaterLayers).toHaveLength(1)
+    expect(midwaterSheet).toBeDefined()
     expect(heroRimLight).toBeDefined()
     expect(heroGroundGlow).toBeDefined()
 
-    expect(getWidthRatio(nearSurfaceBands[0].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(-0.325)
-    expect(getWidthRatio(nearSurfaceBands[0].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(-0.3)
-    expect(getWidthRatio(nearSurfaceBands[2].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.01)
-    expect(getWidthRatio(nearSurfaceBands[2].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.025)
-    expect(getWidthRatio(nearSurfaceBands[4].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.3)
-    expect(getWidthRatio(nearSurfaceBands[4].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.325)
-    expect(nearSurfaceBands.every((mesh) => (
+    expect(getWidthRatio(nearSurfaceSheets[0].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.01)
+    expect(getWidthRatio(nearSurfaceSheets[0].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.025)
+    expect((nearSurfaceSheets[0].geometry as THREE.PlaneGeometry).parameters.width).toBeGreaterThan(
+      EXPANDED_TANK_DIMENSIONS.width * 1.4
+    )
+    expect(nearSurfaceSheets.every((mesh) => (
       getTopClearanceRatio(mesh.position, EXPANDED_TANK_DIMENSIONS) > 0.18 &&
       getTopClearanceRatio(mesh.position, EXPANDED_TANK_DIMENSIONS) < 0.22
     ))).toBe(true)
-    expect(getWidthRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.02)
-    expect(getWidthRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.035)
-    expect(getHeightRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.08)
-    expect(getHeightRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.09)
-    expect(getDepthRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(-0.18)
-    expect(getDepthRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(-0.16)
+    expect(getWidthRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.02)
+    expect(getWidthRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.035)
+    expect(getHeightRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.08)
+    expect(getHeightRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.09)
+    expect(getDepthRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(-0.18)
+    expect(getDepthRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(-0.16)
     expect(getWidthRatio(lightCanopy!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.034)
     expect(getWidthRatio(lightCanopy!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.046)
     expect(getTopClearanceRatio(lightCanopy!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.11)
@@ -1292,17 +1614,17 @@ describe('AdvancedAquariumScene tank backdrop', () => {
     const midwaterLayers = internals.tank.children.filter((child) => (
       child.name.startsWith('tank-light-midwater-')
     )) as THREE.Mesh[]
-    const midwaterBreakup = midwaterLayers.find((child) => child.name === 'tank-light-midwater-breakup')
+    const midwaterSheet = midwaterLayers.find((child) => child.name === 'tank-light-midwater-sheet')
 
     expect(driftwoodOcclusion).toBeDefined()
     expect(ridgeOcclusion).toBeDefined()
     expect(backwallOcclusion).toBeDefined()
-    expect(midwaterBreakup).toBeDefined()
+    expect(midwaterSheet).toBeDefined()
     expect(driftwoodOcclusion?.position.x).toBeLessThan(0.2)
     expect(ridgeOcclusion?.position.x).toBeGreaterThan(1.2)
     expect(backwallOcclusion?.position.z).toBeLessThan(-4.6)
-    expect(driftwoodOcclusion?.renderOrder).toBeGreaterThan(midwaterBreakup?.renderOrder ?? 0)
-    expect(ridgeOcclusion?.renderOrder).toBeGreaterThan(midwaterBreakup?.renderOrder ?? 0)
+    expect(driftwoodOcclusion?.renderOrder).toBeGreaterThan(midwaterSheet?.renderOrder ?? 0)
+    expect(ridgeOcclusion?.renderOrder).toBeGreaterThan(midwaterSheet?.renderOrder ?? 0)
     expect((driftwoodOcclusion?.material as THREE.MeshBasicMaterial | undefined)?.blending).toBe(THREE.NormalBlending)
     expect((driftwoodOcclusion?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThan(0.125)
     expect((ridgeOcclusion?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeLessThan(0.145)
@@ -2532,14 +2854,13 @@ describe('AdvancedAquariumScene quality scaling', () => {
     const midground = internals.tank.children.find((child) => child.name === 'tank-depth-midground') as THREE.Mesh | undefined
     const foreground = internals.tank.children.find((child) => child.name === 'tank-depth-foreground-shadow') as THREE.Mesh | undefined
     const lightCanopy = internals.tank.children.find((child) => child.name === 'tank-light-canopy') as THREE.Mesh | undefined
-    const nearSurfaceBands = internals.tank.children.filter((child) => (
-      child.name.startsWith('tank-light-near-surface-band-')
+    const nearSurfaceSheets = internals.tank.children.filter((child) => (
+      child.name.startsWith('tank-light-near-surface-')
     )) as THREE.Mesh[]
     const midwaterLayers = internals.tank.children.filter((child) => (
       child.name.startsWith('tank-light-midwater-')
     )) as THREE.Mesh[]
-    const midwaterFill = midwaterLayers.find((child) => child.name === 'tank-light-midwater-fill')
-    const midwaterBreakup = midwaterLayers.find((child) => child.name === 'tank-light-midwater-breakup')
+    const midwaterSheet = midwaterLayers.find((child) => child.name === 'tank-light-midwater-sheet')
     const heroRimLight = internals.tank.children.find((child) => child.name === 'tank-hero-rim-light') as THREE.Mesh | undefined
     const heroGroundGlow = internals.tank.children.find((child) => child.name === 'tank-hero-ground-glow') as THREE.Mesh | undefined
     const driftwoodOcclusion = internals.tank.children.find((child) => child.name === 'tank-hardscape-occlusion-driftwood') as THREE.Mesh | undefined
@@ -2549,32 +2870,28 @@ describe('AdvancedAquariumScene quality scaling', () => {
     expect(internals.renderer.setPixelRatio).toHaveBeenCalledWith(1)
     expect(internals.renderer.shadowMap.enabled).toBe(true)
     expect(internals.renderer.shadowMap.type).toBe(THREE.PCFShadowMap)
-    expect(internals.primaryShadowLight?.shadow.mapSize.width).toBe(2048)
-    expect(internals.primaryShadowLight?.shadow.mapSize.height).toBe(2048)
+    expect(internals.primaryShadowLight?.shadow.mapSize.width).toBe(1024)
+    expect(internals.primaryShadowLight?.shadow.mapSize.height).toBe(1024)
     expect(waterVolume?.visible).toBe(true)
     expect(caustics?.visible).toBe(true)
     expect(waterSurface?.visible).toBe(true)
     expect(waterSurfaceHighlight?.visible).toBe(false)
-    expect(frontGlassHighlight?.visible).toBe(true)
-    expect(leftEdgeHighlight?.visible).toBe(true)
+    expect(frontGlassHighlight).toBeUndefined()
+    expect(leftEdgeHighlight).toBeUndefined()
     expect(waterlineFront?.visible).toBe(false)
     expect(midground?.visible).toBe(true)
     expect(foreground?.visible).toBe(false)
     expect(lightCanopy?.visible).toBe(true)
-    expect(nearSurfaceBands).toHaveLength(5)
-    expect(nearSurfaceBands.every((mesh) => mesh.visible)).toBe(true)
-    expect(midwaterFill?.visible).toBe(true)
-    expect(midwaterBreakup?.visible).toBe(true)
+    expect(nearSurfaceSheets).toHaveLength(1)
+    expect(nearSurfaceSheets.every((mesh) => mesh.visible)).toBe(true)
+    expect(midwaterSheet?.visible).toBe(true)
     expect(getTopClearanceRatio(lightCanopy!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.11)
     expect(getTopClearanceRatio(lightCanopy!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.118)
-    expect(getWidthRatio(nearSurfaceBands[0].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(-0.325)
-    expect(getWidthRatio(nearSurfaceBands[0].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(-0.3)
-    expect(getWidthRatio(nearSurfaceBands[4].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.3)
-    expect(getWidthRatio(nearSurfaceBands[4].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.325)
-    expect(getDepthRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(-0.18)
-    expect(getDepthRatio(midwaterFill!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(-0.16)
-    expect((midwaterFill?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeGreaterThan(0)
-    expect((midwaterBreakup?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeGreaterThan(0)
+    expect(getWidthRatio(nearSurfaceSheets[0].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.01)
+    expect(getWidthRatio(nearSurfaceSheets[0].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.025)
+    expect(getDepthRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(-0.18)
+    expect(getDepthRatio(midwaterSheet!.position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(-0.16)
+    expect((midwaterSheet?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeGreaterThan(0)
     expect(heroRimLight?.visible).toBe(true)
     expect(heroGroundGlow?.visible).toBe(true)
     expect(getBottomClearanceRatio(heroGroundGlow!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.055)
@@ -2630,8 +2947,8 @@ describe('AdvancedAquariumScene quality scaling', () => {
     const midground = internals.tank.children.find((child) => child.name === 'tank-depth-midground') as THREE.Mesh | undefined
     const foreground = internals.tank.children.find((child) => child.name === 'tank-depth-foreground-shadow') as THREE.Mesh | undefined
     const lightCanopy = internals.tank.children.find((child) => child.name === 'tank-light-canopy') as THREE.Mesh | undefined
-    const nearSurfaceBands = internals.tank.children.filter((child) => (
-      child.name.startsWith('tank-light-near-surface-band-')
+    const nearSurfaceSheets = internals.tank.children.filter((child) => (
+      child.name.startsWith('tank-light-near-surface-')
     )) as THREE.Mesh[]
     const midwaterLayers = internals.tank.children.filter((child) => (
       child.name.startsWith('tank-light-midwater-')
@@ -2642,15 +2959,15 @@ describe('AdvancedAquariumScene quality scaling', () => {
 
     expect(internals.renderer.shadowMap.enabled).toBe(true)
     expect(internals.renderer.shadowMap.type).toBe(THREE.PCFSoftShadowMap)
-    expect(internals.primaryShadowLight?.shadow.mapSize.width).toBe(4096)
+    expect(internals.primaryShadowLight?.shadow.mapSize.width).toBe(2048)
     expect(midground?.visible).toBe(true)
     expect(foreground?.visible).toBe(true)
     expect(lightCanopy?.visible).toBe(true)
-    expect(nearSurfaceBands).toHaveLength(5)
-    expect(nearSurfaceBands.every((mesh) => mesh.visible)).toBe(true)
-    expect(getWidthRatio(nearSurfaceBands[2].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.01)
-    expect(getWidthRatio(nearSurfaceBands[2].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.025)
-    expect(midwaterLayers).toHaveLength(2)
+    expect(nearSurfaceSheets).toHaveLength(1)
+    expect(nearSurfaceSheets.every((mesh) => mesh.visible)).toBe(true)
+    expect(getWidthRatio(nearSurfaceSheets[0].position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.01)
+    expect(getWidthRatio(nearSurfaceSheets[0].position, EXPANDED_TANK_DIMENSIONS)).toBeLessThan(0.025)
+    expect(midwaterLayers).toHaveLength(1)
     expect(midwaterLayers.every((mesh) => mesh.visible)).toBe(true)
     expect(heroRimLight?.visible).toBe(true)
     expect(getWidthRatio(heroRimLight!.position, EXPANDED_TANK_DIMENSIONS)).toBeGreaterThan(0.135)
@@ -2840,7 +3157,6 @@ describe('AdvancedAquariumScene theme application', () => {
 
     const midground = internals.tank.children.find((child) => child.name === 'tank-depth-midground') as THREE.Mesh | undefined
     const foreground = internals.tank.children.find((child) => child.name === 'tank-depth-foreground-shadow') as THREE.Mesh | undefined
-    const frontHighlight = internals.tank.children.find((child) => child.name === 'tank-glass-front-highlight') as THREE.Mesh | undefined
     const waterSurfaceHighlight = internals.tank.children.find((child) => child.name === 'tank-water-surface-highlight') as THREE.Mesh | undefined
     const waterlineFront = internals.tank.children.find((child) => child.name === 'tank-waterline-front') as THREE.Mesh | undefined
     const lightCanopy = internals.tank.children.find((child) => child.name === 'tank-light-canopy') as THREE.Mesh | undefined
@@ -2858,13 +3174,11 @@ describe('AdvancedAquariumScene theme application', () => {
     )) as THREE.Mesh | undefined
     const midgroundMaterial = midground?.material as THREE.MeshBasicMaterial | undefined
     const foregroundMaterial = foreground?.material as THREE.MeshBasicMaterial | undefined
-    const frontHighlightMaterial = frontHighlight?.material as THREE.MeshBasicMaterial | undefined
 
     expect(midgroundMaterial?.color.getHexString()).not.toBe('3f7880')
     expect(foregroundMaterial?.color.getHexString()).not.toBe('07212a')
     expect(midgroundMaterial?.color.g ?? 0).toBeGreaterThan(midgroundMaterial?.color.b ?? 0)
     expect(foregroundMaterial?.color.g ?? 0).toBeGreaterThan(foregroundMaterial?.color.b ?? 0)
-    expect(frontHighlightMaterial?.color.g ?? 0).toBeGreaterThan(frontHighlightMaterial?.color.b ?? 0)
     expect((waterSurfaceHighlight?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeGreaterThan(0.138)
     expect((waterlineFront?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeGreaterThan(0.094)
     expect((waterSurfaceHighlight?.material as THREE.MeshBasicMaterial | undefined)?.opacity).toBeGreaterThan(

--- a/src/components/AdvancedScene.ts
+++ b/src/components/AdvancedScene.ts
@@ -20,9 +20,23 @@ import { defaultTheme } from '../utils/stateSchema'
 import { disposeSceneResources } from '../utils/threeDisposal'
 import { createOpenWaterBounds } from '../utils/sceneBounds'
 import {
+  applyAssetLoadTimings,
+  createEmptySpanTimingStats,
+  createEmptyPerformanceStats,
+  measurePerformanceSpan,
+  readRendererDebugStats,
+  type PerformanceStats,
+  type SpanTimingStats
+} from '../utils/performanceStats'
+import {
+  DEFAULT_PERFORMANCE_TUNING,
+  type PerformanceTuningOptions
+} from '../utils/performanceTuning'
+import { resolveAdaptiveRenderScale } from '../utils/renderScale'
+import { shouldRunQualityCadencedUpdate } from '../utils/updateCadence'
+import {
   AQUARIUM_CAMERA_FRAMING,
   AQUARIUM_DEPTH_LAYER_ANCHORS,
-  AQUARIUM_FRONT_GLASS_THICKNESS,
   AQUARIUM_TANK_DIMENSIONS,
   MAIN_LIGHT_RIG_ANCHORS,
   MAIN_LIGHT_TARGET_OFFSETS,
@@ -47,13 +61,6 @@ import {
   SUBSTRATE_GEOMETRY_SEGMENTS,
   SUBSTRATE_VISUAL_FOOTPRINT_SCALE
 } from './substrateGeometry'
-
-interface PerformanceStats {
-  fps: number
-  frameTime: number
-  fishVisible: number
-  drawCalls: number
-}
 
 type PhotoModeFollowMode = 'fish' | 'mouse'
 
@@ -757,6 +764,7 @@ export class AdvancedAquariumScene {
   private readonly photoModePointer = new THREE.Vector2()
   private motionScale = 1
   public advancedEffectsEnabled = true
+  private readonly performanceTuning: PerformanceTuningOptions
   private readonly tankDimensions = AQUARIUM_TANK_DIMENSIONS
   private defaultCameraPosition = resolveDefaultCameraPosition(this.tankDimensions)
   private photoModeCameraPosition = resolvePhotoModeCameraPosition(this.tankDimensions)
@@ -766,14 +774,15 @@ export class AdvancedAquariumScene {
   private readonly visualAssets?: VisualAssetBundle
   
   // Performance monitoring
-  private stats: PerformanceStats = {
-    fps: 0,
-    frameTime: 0,
-    fishVisible: 0,
-    drawCalls: 0
-  }
+  private stats: PerformanceStats = createEmptyPerformanceStats()
+  private fishUpdateStats: SpanTimingStats = createEmptySpanTimingStats()
+  private waterMotionUpdateStats: SpanTimingStats = createEmptySpanTimingStats()
   private fpsCounter = 0
   private lastStatsUpdate = 0
+  private adaptiveRenderScale = 1
+  private stressedFrameSamples = 0
+  private stableFrameSamples = 0
+  private waterMotionFrame = 0
   private readonly performanceThresholds = {
     medium: 50,
     low: 30
@@ -782,15 +791,18 @@ export class AdvancedAquariumScene {
   constructor(
     container: HTMLElement,
     visualAssets?: VisualAssetBundle,
-    initialTheme: Theme = defaultTheme
+    initialTheme: Theme = defaultTheme,
+    performanceTuning: PerformanceTuningOptions = DEFAULT_PERFORMANCE_TUNING
   ) {
     this.container = container
     this.visualAssets = visualAssets
+    this.performanceTuning = performanceTuning
+    applyAssetLoadTimings(this.stats, visualAssets?.loadTimings)
     this.currentVisualQuality = 'standard'
     this.scene = new THREE.Scene()
     applyThemeToScene(this.scene, initialTheme)
     this.clock = new THREE.Clock()
-    
+
     this.setupCamera()
     this.setupRenderer(container)
     this.setupComposer()
@@ -850,7 +862,7 @@ export class AdvancedAquariumScene {
       powerPreference: 'high-performance'
     })
     this.renderer.setSize(width, height)
-    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.currentVisualQuality === 'simple' ? 1 : 2))
+    this.renderer.setPixelRatio(this.resolveRendererPixelRatio())
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping
     this.renderer.toneMappingExposure = this.resolveToneMappingExposure(this.currentVisualQuality)
     this.renderer.shadowMap.enabled = true
@@ -1541,6 +1553,14 @@ export class AdvancedAquariumScene {
       ? cameraAspect
       : fallbackAspect
 
+    if (this.performanceTuning?.screenSpaceHazeEnabled === false) {
+      if (this.screenSpaceHazePass) {
+        this.screenSpaceHazePass.enabled = false
+      }
+      this.godRaysEffect?.setScreenSpaceWaterHazeEnabled?.(false)
+      return
+    }
+
     syncScreenSpaceWaterHazePass(this.screenSpaceHazePass, theme, quality, aspect)
     this.godRaysEffect?.configureScreenSpaceWaterHaze?.(theme, quality, aspect)
   }
@@ -1548,228 +1568,125 @@ export class AdvancedAquariumScene {
   private createUnderwaterLightingBands(dimensions: AquariumTankDimensions): void {
     const { width: tankWidth, height: tankHeight } = dimensions
 
-    this.nearSurfaceLightMeshes = [
-      {
-        name: 'tank-light-near-surface-band-0',
-        size: new THREE.Vector2(tankWidth * 0.28, tankHeight * 0.52),
-        anchor: AQUARIUM_LAYERED_LIGHTING_ANCHORS.nearSurfaceBands[0],
-        rotationY: 0.12,
-        rotationZ: -0.05,
-        opacity: 0.124,
-        scrollX: 0.0028,
-        scrollY: 0.0078,
-        swayX: 0.1,
-        swayY: 0.045,
-        opacityPulse: 0.04,
-        phase: 0.18,
-        mapRepeatX: 1.18,
-        mapRepeatY: 1.02,
-        mapWarpX: 0.024,
-        mapWarpY: 0.016,
-        mapRotation: 0.038
-      },
-      {
-        name: 'tank-light-near-surface-band-1',
-        size: new THREE.Vector2(tankWidth * 0.26, tankHeight * 0.54),
-        anchor: AQUARIUM_LAYERED_LIGHTING_ANCHORS.nearSurfaceBands[1],
-        rotationY: -0.04,
-        rotationZ: 0.018,
-        opacity: 0.129,
-        scrollX: -0.0021,
-        scrollY: 0.0072,
-        swayX: 0.082,
-        swayY: 0.05,
-        opacityPulse: 0.05,
-        phase: 0.72,
-        mapRepeatX: 1.12,
-        mapRepeatY: 1.04,
-        mapWarpX: 0.022,
-        mapWarpY: 0.015,
-        mapRotation: 0.032
-      },
-      {
-        name: 'tank-light-near-surface-band-2',
-        size: new THREE.Vector2(tankWidth * 0.34, tankHeight * 0.58),
-        anchor: AQUARIUM_LAYERED_LIGHTING_ANCHORS.nearSurfaceBands[2],
-        rotationY: -0.09,
-        rotationZ: -0.016,
-        opacity: 0.136,
-        scrollX: 0.0014,
-        scrollY: 0.0068,
-        swayX: 0.072,
-        swayY: 0.052,
-        opacityPulse: 0.05,
-        phase: 1.24,
-        mapRepeatX: 1.24,
-        mapRepeatY: 1.06,
-        mapWarpX: 0.026,
-        mapWarpY: 0.017,
-        mapRotation: 0.036
-      },
-      {
-        name: 'tank-light-near-surface-band-3',
-        size: new THREE.Vector2(tankWidth * 0.28, tankHeight * 0.54),
-        anchor: AQUARIUM_LAYERED_LIGHTING_ANCHORS.nearSurfaceBands[3],
-        rotationY: -0.08,
-        rotationZ: 0.024,
-        opacity: 0.129,
-        scrollX: -0.0018,
-        scrollY: 0.0076,
-        swayX: 0.088,
-        swayY: 0.046,
-        opacityPulse: 0.045,
-        phase: 1.84,
-        mapRepeatX: 1.14,
-        mapRepeatY: 1.03,
-        mapWarpX: 0.023,
-        mapWarpY: 0.015,
-        mapRotation: 0.03
-      },
-      {
-        name: 'tank-light-near-surface-band-4',
-        size: new THREE.Vector2(tankWidth * 0.29, tankHeight * 0.5),
-        anchor: AQUARIUM_LAYERED_LIGHTING_ANCHORS.nearSurfaceBands[4],
-        rotationY: -0.14,
-        rotationZ: -0.02,
-        opacity: 0.12,
-        scrollX: 0.0025,
-        scrollY: 0.0074,
-        swayX: 0.102,
-        swayY: 0.044,
-        opacityPulse: 0.04,
-        phase: 2.36,
-        mapRepeatX: 1.16,
-        mapRepeatY: 1.01,
-        mapWarpX: 0.024,
-        mapWarpY: 0.014,
-        mapRotation: 0.04
-      }
-    ].map((config) => {
-      const texture = this.createNearSurfaceLightTexture()
-      texture.repeat.set(config.mapRepeatX, config.mapRepeatY)
-      const mesh = new THREE.Mesh(
-        new THREE.PlaneGeometry(config.size.x, config.size.y),
-        new THREE.MeshBasicMaterial({
-          map: texture,
+    const nearSurfaceTexture = this.createNearSurfaceLightTexture()
+    const nearSurfaceConfig = {
+      name: 'tank-light-near-surface-sheet',
+      size: new THREE.Vector2(tankWidth * 1.55, tankHeight * 0.62),
+      anchor: AQUARIUM_LAYERED_LIGHTING_ANCHORS.nearSurfaceBands[2],
+      rotationY: -0.08,
+      rotationZ: -0.01,
+      opacity: 0.13,
+      scrollX: 0.0014,
+      scrollY: 0.0072,
+      swayX: 0.075,
+      swayY: 0.05,
+      opacityPulse: 0.048,
+      phase: 1.24,
+      mapRepeatX: 1.2,
+      mapRepeatY: 1.04,
+      mapWarpX: 0.025,
+      mapWarpY: 0.016,
+      mapRotation: 0.036
+    }
+    nearSurfaceTexture.repeat.set(nearSurfaceConfig.mapRepeatX, nearSurfaceConfig.mapRepeatY)
+    const nearSurfacePosition = resolveTankRelativePosition(dimensions, nearSurfaceConfig.anchor)
+    const nearSurfaceMesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(nearSurfaceConfig.size.x, nearSurfaceConfig.size.y),
+      new THREE.MeshBasicMaterial({
+        map: nearSurfaceTexture,
         color: new THREE.Color('#ddd9c7'),
-          transparent: true,
-          opacity: config.opacity,
-          blending: THREE.AdditiveBlending,
-          depthWrite: false,
-          side: THREE.DoubleSide
-        })
-      )
-      const position = resolveTankRelativePosition(dimensions, config.anchor)
-      mesh.name = config.name
-      mesh.position.copy(position)
-      mesh.rotation.y = config.rotationY
-      mesh.rotation.z = config.rotationZ
-      mesh.renderOrder = 2
-      mesh.userData.baseOpacity = config.opacity
-      mesh.userData.baseX = position.x
-      mesh.userData.baseY = position.y
-      mesh.userData.scrollX = config.scrollX
-      mesh.userData.scrollY = config.scrollY
-      mesh.userData.swayX = config.swayX
-      mesh.userData.swayY = config.swayY
-      mesh.userData.opacityPulse = config.opacityPulse
-      mesh.userData.phase = config.phase
-      mesh.userData.phaseFamily = SURFACE_CAUSTIC_PHASE_FAMILY
-      mesh.userData.mapRepeatX = config.mapRepeatX
-      mesh.userData.mapRepeatY = config.mapRepeatY
-      mesh.userData.mapWarpX = config.mapWarpX
-      mesh.userData.mapWarpY = config.mapWarpY
-      mesh.userData.mapRotation = config.mapRotation
-      this.tank.add(mesh)
-      return mesh
-    })
+        transparent: true,
+        opacity: nearSurfaceConfig.opacity,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        side: THREE.DoubleSide
+      })
+    )
+    nearSurfaceMesh.name = nearSurfaceConfig.name
+    nearSurfaceMesh.position.copy(nearSurfacePosition)
+    nearSurfaceMesh.rotation.y = nearSurfaceConfig.rotationY
+    nearSurfaceMesh.rotation.z = nearSurfaceConfig.rotationZ
+    nearSurfaceMesh.renderOrder = 2
+    nearSurfaceMesh.userData.baseOpacity = nearSurfaceConfig.opacity
+    nearSurfaceMesh.userData.baseX = nearSurfacePosition.x
+    nearSurfaceMesh.userData.baseY = nearSurfacePosition.y
+    nearSurfaceMesh.userData.scrollX = nearSurfaceConfig.scrollX
+    nearSurfaceMesh.userData.scrollY = nearSurfaceConfig.scrollY
+    nearSurfaceMesh.userData.swayX = nearSurfaceConfig.swayX
+    nearSurfaceMesh.userData.swayY = nearSurfaceConfig.swayY
+    nearSurfaceMesh.userData.opacityPulse = nearSurfaceConfig.opacityPulse
+    nearSurfaceMesh.userData.phase = nearSurfaceConfig.phase
+    nearSurfaceMesh.userData.phaseFamily = SURFACE_CAUSTIC_PHASE_FAMILY
+    nearSurfaceMesh.userData.mapRepeatX = nearSurfaceConfig.mapRepeatX
+    nearSurfaceMesh.userData.mapRepeatY = nearSurfaceConfig.mapRepeatY
+    nearSurfaceMesh.userData.mapWarpX = nearSurfaceConfig.mapWarpX
+    nearSurfaceMesh.userData.mapWarpY = nearSurfaceConfig.mapWarpY
+    nearSurfaceMesh.userData.mapRotation = nearSurfaceConfig.mapRotation
+    this.tank.add(nearSurfaceMesh)
+    this.nearSurfaceLightMeshes = [nearSurfaceMesh]
 
     const midwaterPosition = resolveTankRelativePosition(dimensions, AQUARIUM_LAYERED_LIGHTING_ANCHORS.midwater)
-    this.midwaterLightMeshes = [
-      {
-        name: 'tank-light-midwater-fill',
-        size: new THREE.Vector2(tankWidth * 0.88, tankHeight * 0.62),
-        position: midwaterPosition.clone(),
-        rotationY: -0.06,
-        rotationZ: 0.028,
-        opacity: 0.074,
-        scrollX: 0.0011,
-        scrollY: 0.0038,
-        swayX: 0.055,
-        swayY: 0.042,
-        swayZ: 0.045,
-        opacityPulse: 0.035,
-        phase: 0.44,
-        mapRepeatX: 1.08,
-        mapRepeatY: 1.02,
-        mapWarpX: 0.015,
-        mapWarpY: 0.012,
-        mapRotation: 0.02,
-        variant: 'fill' as const
-      },
-      {
-        name: 'tank-light-midwater-breakup',
-        size: new THREE.Vector2(tankWidth * 0.6, tankHeight * 0.52),
-        position: midwaterPosition.clone().add(new THREE.Vector3(-tankWidth * 0.014, -tankHeight * 0.018, tankWidth * 0.008)),
-        rotationY: -0.1,
-        rotationZ: -0.014,
-        opacity: 0.088,
-        scrollX: -0.0008,
-        scrollY: 0.0049,
-        swayX: 0.042,
-        swayY: 0.048,
-        swayZ: 0.054,
-        opacityPulse: 0.042,
-        phase: 1.02,
-        mapRepeatX: 1.16,
-        mapRepeatY: 1.08,
-        mapWarpX: 0.019,
-        mapWarpY: 0.014,
-        mapRotation: 0.028,
-        variant: 'breakup' as const
-      }
-    ].map((config) => {
-      const texture = this.createMidwaterLightTexture(config.variant)
-      texture.repeat.set(config.mapRepeatX, config.mapRepeatY)
-      const mesh = new THREE.Mesh(
-        new THREE.PlaneGeometry(config.size.x, config.size.y),
-        new THREE.MeshBasicMaterial({
-          map: texture,
+    const midwaterConfig = {
+      name: 'tank-light-midwater-sheet',
+      size: new THREE.Vector2(tankWidth * 0.9, tankHeight * 0.64),
+      position: midwaterPosition.clone(),
+      rotationY: -0.08,
+      rotationZ: 0.014,
+      opacity: 0.084,
+      scrollX: 0.0002,
+      scrollY: 0.0044,
+      swayX: 0.05,
+      swayY: 0.045,
+      swayZ: 0.052,
+      opacityPulse: 0.04,
+      phase: 0.72,
+      mapRepeatX: 1.12,
+      mapRepeatY: 1.05,
+      mapWarpX: 0.018,
+      mapWarpY: 0.013,
+      mapRotation: 0.024,
+      variant: 'combined' as const
+    }
+    const midwaterTexture = this.createMidwaterLightTexture(midwaterConfig.variant)
+    midwaterTexture.repeat.set(midwaterConfig.mapRepeatX, midwaterConfig.mapRepeatY)
+    const midwaterMesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(midwaterConfig.size.x, midwaterConfig.size.y),
+      new THREE.MeshBasicMaterial({
+        map: midwaterTexture,
         color: new THREE.Color('#d4d2c0'),
-          transparent: true,
-          opacity: config.opacity,
-          blending: THREE.AdditiveBlending,
-          depthWrite: false,
-          side: THREE.DoubleSide
-        })
-      )
-      mesh.name = config.name
-      mesh.position.copy(config.position)
-      mesh.rotation.y = config.rotationY
-      mesh.rotation.z = config.rotationZ
-      mesh.renderOrder = 2
-      mesh.userData.baseOpacity = config.opacity
-      mesh.userData.baseX = config.position.x
-      mesh.userData.baseY = config.position.y
-      mesh.userData.baseZ = config.position.z
-      mesh.userData.baseRotationZ = config.rotationZ
-      mesh.userData.scrollX = config.scrollX
-      mesh.userData.scrollY = config.scrollY
-      mesh.userData.swayX = config.swayX
-      mesh.userData.swayY = config.swayY
-      mesh.userData.swayZ = config.swayZ
-      mesh.userData.opacityPulse = config.opacityPulse
-      mesh.userData.phase = config.phase
-      mesh.userData.phaseFamily = SURFACE_CAUSTIC_PHASE_FAMILY
-      mesh.userData.mapRepeatX = config.mapRepeatX
-      mesh.userData.mapRepeatY = config.mapRepeatY
-      mesh.userData.mapWarpX = config.mapWarpX
-      mesh.userData.mapWarpY = config.mapWarpY
-      mesh.userData.mapRotation = config.mapRotation
-      mesh.userData.midwaterLayer = config.variant
-      this.tank.add(mesh)
-      return mesh
-    })
+        transparent: true,
+        opacity: midwaterConfig.opacity,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        side: THREE.DoubleSide
+      })
+    )
+    midwaterMesh.name = midwaterConfig.name
+    midwaterMesh.position.copy(midwaterConfig.position)
+    midwaterMesh.rotation.y = midwaterConfig.rotationY
+    midwaterMesh.rotation.z = midwaterConfig.rotationZ
+    midwaterMesh.renderOrder = 2
+    midwaterMesh.userData.baseOpacity = midwaterConfig.opacity
+    midwaterMesh.userData.baseX = midwaterConfig.position.x
+    midwaterMesh.userData.baseY = midwaterConfig.position.y
+    midwaterMesh.userData.baseZ = midwaterConfig.position.z
+    midwaterMesh.userData.baseRotationZ = midwaterConfig.rotationZ
+    midwaterMesh.userData.scrollX = midwaterConfig.scrollX
+    midwaterMesh.userData.scrollY = midwaterConfig.scrollY
+    midwaterMesh.userData.swayX = midwaterConfig.swayX
+    midwaterMesh.userData.swayY = midwaterConfig.swayY
+    midwaterMesh.userData.swayZ = midwaterConfig.swayZ
+    midwaterMesh.userData.opacityPulse = midwaterConfig.opacityPulse
+    midwaterMesh.userData.phase = midwaterConfig.phase
+    midwaterMesh.userData.phaseFamily = SURFACE_CAUSTIC_PHASE_FAMILY
+    midwaterMesh.userData.mapRepeatX = midwaterConfig.mapRepeatX
+    midwaterMesh.userData.mapRepeatY = midwaterConfig.mapRepeatY
+    midwaterMesh.userData.mapWarpX = midwaterConfig.mapWarpX
+    midwaterMesh.userData.mapWarpY = midwaterConfig.mapWarpY
+    midwaterMesh.userData.mapRotation = midwaterConfig.mapRotation
+    midwaterMesh.userData.midwaterLayer = midwaterConfig.variant
+    this.tank.add(midwaterMesh)
+    this.midwaterLightMeshes = [midwaterMesh]
   }
 
   private createHardscapeOcclusionLayers(dimensions: AquariumTankDimensions): void {
@@ -2412,105 +2329,10 @@ export class AdvancedAquariumScene {
   }
 
   private createGlassShell(dimensions: AquariumTankDimensions): void {
-    const { width: tankWidth, height: tankHeight, depth: tankDepth } = dimensions
-    const theme = this.scene instanceof THREE.Scene ? resolveTheme(this.scene) : defaultTheme
-    const useOpenWaterPresentation = usesOpenWaterPresentation(theme)
-
-    const thickness = AQUARIUM_FRONT_GLASS_THICKNESS
-    const halfDepth = tankDepth / 2
-    const halfWidth = tankWidth / 2
-    const halfHeight = tankHeight / 2
-    const glassMaterial = this.createGlassMaterial()
-
-    const frontGlass = new THREE.Mesh(new THREE.PlaneGeometry(tankWidth, tankHeight), glassMaterial.clone())
-    frontGlass.name = 'tank-glass-front'
-    frontGlass.position.set(0, 0, halfDepth + thickness)
-    this.tank.add(frontGlass)
-
-    const frontHighlight = new THREE.Mesh(
-      new THREE.PlaneGeometry(tankWidth * 0.92, tankHeight * 0.88),
-      new THREE.MeshBasicMaterial({
-        map: this.createGlassHighlightTexture(),
-        color: new THREE.Color('#dde2d7'),
-        transparent: true,
-        opacity: useOpenWaterPresentation ? 0.01 : 0.088,
-        blending: THREE.AdditiveBlending,
-        depthWrite: false,
-        side: THREE.DoubleSide
-      })
-    )
-    frontHighlight.name = 'tank-glass-front-highlight'
-    frontHighlight.position.set(0, 0.2, halfDepth + thickness + 0.014)
-    frontHighlight.renderOrder = 4
-    frontHighlight.userData.baseOpacity = useOpenWaterPresentation ? 0.01 : 0.088
-    this.frontGlassHighlightMesh = frontHighlight
-    this.tank.add(frontHighlight)
-
-    const createEdgeHighlight = (name: string, x: number, rotationY: number): THREE.Mesh => {
-      const edgeHighlight = new THREE.Mesh(
-        new THREE.PlaneGeometry(0.28, tankHeight * 0.84),
-        new THREE.MeshBasicMaterial({
-          map: this.createGlassHighlightTexture(),
-          color: new THREE.Color('#e2e5da'),
-          transparent: true,
-          opacity: 0.07,
-          blending: THREE.AdditiveBlending,
-          depthWrite: false,
-          side: THREE.DoubleSide
-        })
-      )
-      edgeHighlight.name = name
-      edgeHighlight.position.set(x, 0.12, halfDepth + thickness + 0.016)
-      edgeHighlight.rotation.y = rotationY
-      edgeHighlight.renderOrder = 5
-      edgeHighlight.userData.baseOpacity = 0.07
-      edgeHighlight.userData.baseY = 0.12
-      this.tank.add(edgeHighlight)
-      return edgeHighlight
-    }
-
-    const leftEdgeHighlight = createEdgeHighlight('tank-glass-edge-highlight-left', -halfWidth + 0.12, 0.1)
-    const rightEdgeHighlight = createEdgeHighlight('tank-glass-edge-highlight-right', halfWidth - 0.12, -0.1)
-    leftEdgeHighlight.visible = !useOpenWaterPresentation
-    rightEdgeHighlight.visible = !useOpenWaterPresentation
-
-    const leftGlass = new THREE.Mesh(new THREE.PlaneGeometry(tankDepth, tankHeight), glassMaterial.clone())
-    leftGlass.name = 'tank-glass-left'
-    leftGlass.rotation.y = Math.PI / 2
-    leftGlass.position.set(-halfWidth - thickness, 0, 0)
-    leftGlass.visible = !useOpenWaterPresentation
-    this.tank.add(leftGlass)
-
-    const rightGlass = new THREE.Mesh(new THREE.PlaneGeometry(tankDepth, tankHeight), glassMaterial.clone())
-    rightGlass.name = 'tank-glass-right'
-    rightGlass.rotation.y = -Math.PI / 2
-    rightGlass.position.set(halfWidth + thickness, 0, 0)
-    rightGlass.visible = !useOpenWaterPresentation
-    this.tank.add(rightGlass)
-
-    const backGlass = new THREE.Mesh(new THREE.PlaneGeometry(tankWidth, tankHeight), glassMaterial.clone())
-    backGlass.name = 'tank-glass-back'
-    backGlass.rotation.y = Math.PI
-    backGlass.position.set(0, 0, -halfDepth - thickness)
-    backGlass.visible = !useOpenWaterPresentation
-    this.tank.add(backGlass)
-
-    const edgeMaterial = new THREE.MeshStandardMaterial({
-      color: 0xaab6af,
-      roughness: 0.48,
-      metalness: 0.1,
-      transparent: true,
-      opacity: 0.14
-    })
-
-    const topEdge = new THREE.Mesh(new THREE.BoxGeometry(tankWidth + 0.12, 0.08, 0.08), edgeMaterial)
-    topEdge.name = 'tank-glass-edge-top'
-    topEdge.position.set(0, halfHeight + 0.02, halfDepth + 0.02)
-    topEdge.visible = !useOpenWaterPresentation
-    this.tank.add(topEdge)
-
-    this.glassPanes = [frontGlass, leftGlass, rightGlass, backGlass]
-    this.glassEdgeHighlightMeshes = [leftEdgeHighlight, rightEdgeHighlight]
+    void dimensions
+    this.glassPanes = []
+    this.glassEdgeHighlightMeshes = []
+    this.frontGlassHighlightMesh = null
   }
 
   private createInteriorWallPanels(dimensions: AquariumTankDimensions): void {
@@ -2567,28 +2389,6 @@ export class AdvancedAquariumScene {
     this.tank.add(rightPanel)
 
     this.wallPanelMeshes = [backPanel, leftPanel, rightPanel]
-  }
-
-  private createGlassMaterial(): THREE.MeshPhysicalMaterial {
-    return new THREE.MeshPhysicalMaterial({
-      color: 0xb7c3ba,
-      transmission: 0.96,
-      transparent: true,
-      opacity: 0.12,
-      roughness: 0.08,
-      metalness: 0,
-      thickness: 0.42,
-      ior: 1.18,
-      clearcoat: 1,
-      clearcoatRoughness: 0.1,
-      attenuationColor: new THREE.Color('#cad3c8'),
-      attenuationDistance: 2.1,
-      specularIntensity: 0.62,
-      specularColor: new THREE.Color('#ffffff'),
-      envMapIntensity: 1.08,
-      side: THREE.DoubleSide,
-      depthWrite: false
-    })
   }
 
   private createWaterVolume(dimensions: AquariumTankDimensions): void {
@@ -2920,15 +2720,17 @@ export class AdvancedAquariumScene {
     return texture
   }
 
-  private createMidwaterLightTexture(variant: 'fill' | 'breakup'): THREE.CanvasTexture {
+  private createMidwaterLightTexture(variant: 'fill' | 'breakup' | 'combined'): THREE.CanvasTexture {
     const canvas = document.createElement('canvas')
     canvas.width = 512
     canvas.height = 512
     const ctx = canvas.getContext('2d')
     const texture = new THREE.CanvasTexture(canvas)
+    const includesFill = variant === 'fill' || variant === 'combined'
+    const includesBreakup = variant === 'breakup' || variant === 'combined'
     texture.wrapS = THREE.RepeatWrapping
     texture.wrapT = THREE.RepeatWrapping
-    texture.repeat.set(1.08, variant === 'fill' ? 1.02 : 1.08)
+    texture.repeat.set(1.08, includesFill && !includesBreakup ? 1.02 : 1.08)
 
     if (
       !ctx ||
@@ -2948,7 +2750,7 @@ export class AdvancedAquariumScene {
     ctx.fillRect(0, 0, canvas.width, canvas.height)
 
     const verticalFalloff = ctx.createLinearGradient(0, 0, 0, canvas.height)
-    if (variant === 'fill') {
+    if (includesFill) {
       verticalFalloff.addColorStop(0, 'rgba(236, 240, 228, 0.36)')
       verticalFalloff.addColorStop(0.16, 'rgba(199, 206, 189, 0.26)')
       verticalFalloff.addColorStop(0.46, 'rgba(124, 136, 117, 0.11)')
@@ -2964,7 +2766,7 @@ export class AdvancedAquariumScene {
     ctx.fillRect(0, 0, canvas.width, canvas.height)
 
     ctx.globalCompositeOperation = 'screen'
-    if (variant === 'fill') {
+    if (includesFill) {
       [
         { x: 0.18, y: 0.26, radius: 126, alpha: 0.11 },
         { x: 0.42, y: 0.22, radius: 152, alpha: 0.15 },
@@ -2990,7 +2792,8 @@ export class AdvancedAquariumScene {
           wash.radius * 2
         )
       })
-    } else {
+    }
+    if (includesBreakup) {
       [
         { x: 0.34, topWidth: 72, midWidth: 122, bottomWidth: 164, drift: -18, alpha: 0.13 },
         { x: 0.58, topWidth: 62, midWidth: 112, bottomWidth: 150, drift: 12, alpha: 0.12 },
@@ -3029,9 +2832,9 @@ export class AdvancedAquariumScene {
 
     ctx.globalCompositeOperation = 'destination-out'
     ;[
-      { x: 0.18, y: 0.5, radius: 88, alpha: variant === 'fill' ? 0.18 : 0.26 },
-      { x: 0.52, y: 0.68, radius: 116, alpha: variant === 'fill' ? 0.22 : 0.32 },
-      { x: 0.78, y: 0.82, radius: 104, alpha: variant === 'fill' ? 0.2 : 0.28 }
+      { x: 0.18, y: 0.5, radius: 88, alpha: variant === 'fill' ? 0.18 : variant === 'combined' ? 0.22 : 0.26 },
+      { x: 0.52, y: 0.68, radius: 116, alpha: variant === 'fill' ? 0.22 : variant === 'combined' ? 0.27 : 0.32 },
+      { x: 0.78, y: 0.82, radius: 104, alpha: variant === 'fill' ? 0.2 : variant === 'combined' ? 0.24 : 0.28 }
     ].forEach((breakup) => {
       const erode = ctx.createRadialGradient(
         canvas.width * breakup.x,
@@ -3047,7 +2850,7 @@ export class AdvancedAquariumScene {
       ctx.fillRect(0, 0, canvas.width, canvas.height)
     })
 
-    if (variant === 'breakup') {
+    if (includesBreakup) {
       const lowerShear = ctx.createLinearGradient(0, canvas.height * 0.48, 0, canvas.height)
       lowerShear.addColorStop(0, 'rgba(255, 255, 255, 0)')
       lowerShear.addColorStop(0.54, 'rgba(255, 255, 255, 0.14)')
@@ -3302,48 +3105,6 @@ export class AdvancedAquariumScene {
         glow.radius * 2
       )
     })
-
-    texture.colorSpace = THREE.SRGBColorSpace
-    return texture
-  }
-
-  private createGlassHighlightTexture(): THREE.CanvasTexture {
-    const canvas = document.createElement('canvas')
-    canvas.width = 512
-    canvas.height = 512
-    const ctx = canvas.getContext('2d')
-    const texture = new THREE.CanvasTexture(canvas)
-
-    if (!ctx || typeof ctx.createLinearGradient !== 'function') {
-      return texture
-    }
-
-    ctx.fillStyle = 'rgba(255, 255, 255, 0)'
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
-
-    const verticalGlow = ctx.createLinearGradient(canvas.width * 0.22, 0, canvas.width * 0.72, canvas.height)
-    verticalGlow.addColorStop(0, 'rgba(255, 255, 255, 0)')
-    verticalGlow.addColorStop(0.32, 'rgba(240, 243, 238, 0.14)')
-    verticalGlow.addColorStop(0.56, 'rgba(210, 220, 214, 0.28)')
-    verticalGlow.addColorStop(1, 'rgba(255, 255, 255, 0)')
-    ctx.fillStyle = verticalGlow
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
-
-    if (typeof ctx.createRadialGradient === 'function') {
-      const bloom = ctx.createRadialGradient(
-        canvas.width * 0.62,
-        canvas.height * 0.26,
-        canvas.width * 0.04,
-        canvas.width * 0.62,
-        canvas.height * 0.26,
-        canvas.width * 0.34
-      )
-      bloom.addColorStop(0, 'rgba(241, 244, 239, 0.28)')
-      bloom.addColorStop(0.45, 'rgba(208, 220, 213, 0.14)')
-      bloom.addColorStop(1, 'rgba(255, 255, 255, 0)')
-      ctx.fillStyle = bloom
-      ctx.fillRect(0, 0, canvas.width, canvas.height)
-    }
 
     texture.colorSpace = THREE.SRGBColorSpace
     return texture
@@ -4341,7 +4102,17 @@ export class AdvancedAquariumScene {
     
     if (this.motionEnabled) {
       if (this.fishSystem) {
-        this.fishSystem.update(deltaTime * this.motionScale, elapsedTime * this.motionScale)
+        measurePerformanceSpan(
+          this.fishUpdateStats,
+          {
+            name: 'aquarium:fish:update',
+            startMark: 'aquarium:fish:update:start',
+            endMark: 'aquarium:fish:update:end'
+          },
+          () => {
+            this.fishSystem?.update(deltaTime * this.motionScale, elapsedTime * this.motionScale)
+          }
+        )
       }
       this.syncFishVisibleStat()
       
@@ -4349,17 +4120,44 @@ export class AdvancedAquariumScene {
         this.particleSystem.update(elapsedTime * this.motionScale)
       }
 
-      this.updateTankWaterMotion(elapsedTime * this.motionScale)
+      if (this.shouldUpdateTankWaterMotion()) {
+        measurePerformanceSpan(
+          this.waterMotionUpdateStats,
+          {
+            name: 'aquarium:water-motion:update',
+            startMark: 'aquarium:water-motion:update:start',
+            endMark: 'aquarium:water-motion:update:end'
+          },
+          () => {
+            this.updateTankWaterMotion(elapsedTime * this.motionScale)
+          }
+        )
+      }
       
       if (this.aquascaping) {
         this.aquascaping.update(elapsedTime * this.motionScale)
       }
-      
+
       if (this.spiralDecorations) {
         this.spiralDecorations.update(deltaTime * this.motionScale)
       }
     }
-    
+
+    this.renderSceneFrame(elapsedTime)
+
+    // Update performance stats
+    this.updatePerformanceStats(startTime)
+  }
+
+  private renderSceneFrame(elapsedTime: number): void {
+    if (
+      this.performanceTuning?.postProcessingEnabled === false ||
+      this.currentVisualQuality === 'simple'
+    ) {
+      this.renderer.render(this.scene, this.camera)
+      return
+    }
+
     // Render with or without post-processing
     if (this.godRaysEffect && this.advancedEffectsEnabled) {
       this.godRaysEffect.update(elapsedTime * this.motionScale)
@@ -4369,9 +4167,15 @@ export class AdvancedAquariumScene {
     } else {
       this.renderer.render(this.scene, this.camera)
     }
-    
-    // Update performance stats
-    this.updatePerformanceStats(startTime)
+  }
+
+  private shouldUpdateTankWaterMotion(): boolean {
+    const waterMotionFrame = (this.waterMotionFrame as number | undefined) ?? 0
+    this.waterMotionFrame = waterMotionFrame + 1
+    return shouldRunQualityCadencedUpdate({
+      frame: waterMotionFrame,
+      quality: this.currentVisualQuality
+    })
   }
 
   private resolvePhotoModeTarget(): THREE.Vector3 {
@@ -4669,10 +4473,62 @@ export class AdvancedAquariumScene {
     }
     this.stats.fishVisible = this.fishSystem.getVisibleFishCount()
   }
+
+  private syncGodRaysDepthRenderStats(): void {
+    const depthStats = this.godRaysEffect?.getDepthRenderStats()
+    this.stats.godRaysDepthRenderCount = depthStats?.count ?? 0
+    this.stats.godRaysDepthRenderLastMs = depthStats?.lastMs ?? 0
+    this.stats.godRaysDepthRenderAverageMs = depthStats?.averageMs ?? 0
+  }
+
+  private syncUpdateTimingStats(): void {
+    this.stats.fishUpdateCount = this.fishUpdateStats.count
+    this.stats.fishUpdateLastMs = this.fishUpdateStats.lastMs
+    this.stats.fishUpdateAverageMs = this.fishUpdateStats.averageMs
+    this.stats.waterMotionUpdateCount = this.waterMotionUpdateStats.count
+    this.stats.waterMotionUpdateLastMs = this.waterMotionUpdateStats.lastMs
+    this.stats.waterMotionUpdateAverageMs = this.waterMotionUpdateStats.averageMs
+  }
+
+  private resolveRendererPixelRatio(): number {
+    const pixelRatioCap = this.currentVisualQuality === 'simple' ? 1 : 2
+    return Math.min(window.devicePixelRatio * this.adaptiveRenderScale, pixelRatioCap)
+  }
+
+  private syncAdaptiveRenderScale(frameTimeMs: number): void {
+    if (this.currentVisualQuality !== 'standard') return
+
+    if (frameTimeMs >= 28) {
+      this.stressedFrameSamples++
+      this.stableFrameSamples = 0
+    } else if (frameTimeMs <= 20) {
+      this.stableFrameSamples++
+      this.stressedFrameSamples = 0
+    } else {
+      this.stressedFrameSamples = 0
+      this.stableFrameSamples = 0
+    }
+
+    const nextScale = resolveAdaptiveRenderScale({
+      currentScale: this.adaptiveRenderScale,
+      averageFrameTimeMs: frameTimeMs,
+      stressedSampleCount: this.stressedFrameSamples,
+      stableSampleCount: this.stableFrameSamples
+    })
+    if (nextScale === this.adaptiveRenderScale) return
+
+    this.adaptiveRenderScale = nextScale
+    this.stressedFrameSamples = 0
+    this.stableFrameSamples = 0
+    this.renderer.setPixelRatio(this.resolveRendererPixelRatio())
+  }
   
   private updatePerformanceStats(startTime: number): void {
     this.stats.frameTime = performance.now() - startTime
-    this.stats.drawCalls = this.renderer.info.render.calls
+    this.syncAdaptiveRenderScale(this.stats.frameTime)
+    Object.assign(this.stats, readRendererDebugStats(this.renderer.info))
+    this.syncUpdateTimingStats()
+    this.syncGodRaysDepthRenderStats()
     
     this.fpsCounter++
     if (performance.now() - this.lastStatsUpdate > 1000) {
@@ -4736,8 +4592,11 @@ export class AdvancedAquariumScene {
     this.currentVisualQuality = quality
     this.syncRendererPipelineForQuality(quality)
     const { width, height } = this.getViewportSize()
-    const pixelRatioCap = quality === 'simple' ? 1 : 2
-    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, pixelRatioCap))
+    this.adaptiveRenderScale = 1
+    this.stressedFrameSamples = 0
+    this.stableFrameSamples = 0
+    this.waterMotionFrame = 0
+    this.renderer.setPixelRatio(this.resolveRendererPixelRatio())
     this.renderer.setSize(width, height)
 
     if (this.composer) {
@@ -4843,7 +4702,7 @@ export class AdvancedAquariumScene {
 
   private applyShadowQuality(quality: QualityLevel): void {
     if (!this.primaryShadowLight) return
-    const shadowMapSize = quality === 'simple' ? 2048 : 4096
+    const shadowMapSize = this.performanceTuning?.shadowMapSize ?? (quality === 'simple' ? 1024 : 2048)
     this.primaryShadowLight.shadow.mapSize.width = shadowMapSize
     this.primaryShadowLight.shadow.mapSize.height = shadowMapSize
   }

--- a/src/components/Aquascaping.test.ts
+++ b/src/components/Aquascaping.test.ts
@@ -1161,6 +1161,26 @@ describe('AquascapingSystem composition', () => {
     getContextSpy.mockRestore()
   })
 
+  it('does not add bright procedural sand ripples to the nature-showcase beach', () => {
+    const getContextSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => createMockCanvasContext())
+
+    const scene = new THREE.Scene()
+    const bounds = createOpenWaterBounds()
+
+    new AquascapingSystem(scene, bounds, createAquascapeModelBundle(), {
+      layoutStyle: 'nature-showcase'
+    })
+
+    const aquascapingGroup = scene.children.find((child) => child instanceof THREE.Group) as THREE.Group
+    const sandRipples = aquascapingGroup.children.filter((child) => child.userData.role === 'sand-ripple')
+
+    expect(sandRipples).toHaveLength(0)
+
+    getContextSpy.mockRestore()
+  })
+
   it('layers nature-showcase plants into species-driven colonies instead of a vallis wall', () => {
     const sampledPlantPlacements = resolveSampledPlantPlacements('nature-showcase', 0x53a9d2f1)
     const leftRearPlacements = sampledPlantPlacements.filter((placement) => placement.zoneId === 'left-rear')

--- a/src/components/Aquascaping.ts
+++ b/src/components/Aquascaping.ts
@@ -3593,30 +3593,28 @@ uniform float uDriftwoodRidgeLift;`
   }
 
   private createSandDetails(bounds: THREE.Box3): void {
+    if (this.layoutStyle === 'nature-showcase') return
+
     const rippleGeometry = new THREE.PlaneGeometry(1, 0.1, 10, 1)
     const rippleMaterial = new THREE.MeshPhysicalMaterial({
-      color: this.layoutStyle === 'nature-showcase' ? 0xd1b99a : 0xe8d5b8,
+      color: 0xe8d5b8,
       metalness: 0,
       roughness: 1,
       transparent: true,
-      opacity: this.layoutStyle === 'nature-showcase' ? 0.1 : 0.3
+      opacity: 0.3
     })
     const size = new THREE.Vector3()
     bounds.getSize(size)
-    const rippleSeed = createSeededRandom(this.layoutStyle === 'nature-showcase' ? 7421 : 3611)
-    const rippleCount = this.layoutStyle === 'nature-showcase' ? 4 : 20
+    const rippleSeed = createSeededRandom(3611)
+    const rippleCount = 20
 
     for (let i = 0; i < rippleCount; i++) {
       const ripple = new THREE.Mesh(rippleGeometry, rippleMaterial)
       ripple.rotation.x = -Math.PI / 2
       ripple.rotation.z = rippleSeed() * Math.PI
 
-      const x = this.layoutStyle === 'nature-showcase'
-        ? size.x * (0.22 + rippleSeed() * 0.12)
-        : (rippleSeed() - 0.5) * size.x * 0.9
-      const z = this.layoutStyle === 'nature-showcase'
-        ? size.z * (0.16 + rippleSeed() * 0.1)
-        : (rippleSeed() - 0.5) * size.z * 0.9
+      const x = (rippleSeed() - 0.5) * size.x * 0.9
+      const z = (rippleSeed() - 0.5) * size.z * 0.9
 
       ripple.position.set(
         x,
@@ -3624,9 +3622,7 @@ uniform float uDriftwoodRidgeLift;`
         z
       )
 
-      const scale = this.layoutStyle === 'nature-showcase'
-        ? 0.32 + rippleSeed() * 0.3
-        : 0.5 + rippleSeed() * 2
+      const scale = 0.5 + rippleSeed() * 2
       ripple.scale.set(scale, 1, scale)
       ripple.userData = {
         role: 'sand-ripple'

--- a/src/components/DetailedFish.test.ts
+++ b/src/components/DetailedFish.test.ts
@@ -3411,6 +3411,73 @@ describe('DetailedFishSystem fish group application', () => {
     expect(boidsUpdate).toHaveBeenCalledWith(0.25)
   })
 
+  test('simple quality updates school motion every other frame while keeping hero animation live', () => {
+    const instance = Object.create(DetailedFishSystem.prototype) as DetailedFishSystem
+    const boidsUpdate = vi.fn()
+    const syncInstancedMeshes = vi.fn()
+    const updateHeroAnimations = vi.fn()
+    const internals = instance as unknown as {
+      currentQuality: 'simple'
+      instancedMeshes: THREE.InstancedMesh[]
+      instancedTailMotionUniforms: Array<{ value: number }>
+      boids: { boids: Array<{ position: THREE.Vector3; velocity: THREE.Vector3; acceleration: THREE.Vector3 }>; update: (deltaTime: number) => void }
+      bounds: THREE.Box3
+      behaviorProfile: {
+        preferredDepth: number
+        depthVariance: number
+        turnBias: number
+        schoolMood: 'calm'
+        avoidWalls: number
+      }
+      tempBoundsSize: THREE.Vector3
+      tempDepthForce: THREE.Vector3
+      tempHorizontalDirection: THREE.Vector3
+      tempHorizontalPreviousDirection: THREE.Vector3
+      tempInterestForce: THREE.Vector3
+      updateWanderTargets: (elapsedTime: number) => void
+      ensureHeadingState: () => void
+      ensureMotionStateArrays: () => void
+      applyBehaviorForces: () => void
+      syncInstancedMeshes: typeof syncInstancedMeshes
+      updateHeroAnimations: typeof updateHeroAnimations
+    }
+
+    internals.currentQuality = 'simple'
+    internals.instancedMeshes = []
+    internals.instancedTailMotionUniforms = []
+    internals.boids = { boids: [], update: boidsUpdate }
+    internals.bounds = new THREE.Box3(new THREE.Vector3(-5, -5, -5), new THREE.Vector3(5, 5, 5))
+    internals.behaviorProfile = {
+      preferredDepth: 0.5,
+      depthVariance: 0.18,
+      turnBias: 0.14,
+      schoolMood: 'calm',
+      avoidWalls: 0.8
+    }
+    internals.tempBoundsSize = new THREE.Vector3()
+    internals.tempDepthForce = new THREE.Vector3()
+    internals.tempHorizontalDirection = new THREE.Vector3()
+    internals.tempHorizontalPreviousDirection = new THREE.Vector3()
+    internals.tempInterestForce = new THREE.Vector3()
+    internals.updateWanderTargets = vi.fn()
+    internals.ensureHeadingState = vi.fn()
+    internals.ensureMotionStateArrays = vi.fn()
+    internals.applyBehaviorForces = vi.fn()
+    internals.syncInstancedMeshes = syncInstancedMeshes
+    internals.updateHeroAnimations = updateHeroAnimations
+
+    const update = (DetailedFishSystem.prototype as unknown as {
+      update: (deltaTime: number, elapsedTime: number) => void
+    }).update.bind(instance)
+
+    update(0.016, 1)
+    update(0.016, 1.016)
+
+    expect(boidsUpdate).toHaveBeenCalledTimes(1)
+    expect(syncInstancedMeshes).toHaveBeenCalledTimes(1)
+    expect(updateHeroAnimations).toHaveBeenCalledTimes(2)
+  })
+
   test('update biases fish upward or downward based on the active depth profile', () => {
     const instance = Object.create(DetailedFishSystem.prototype) as DetailedFishSystem
     const boid = {

--- a/src/components/DetailedFish.ts
+++ b/src/components/DetailedFish.ts
@@ -122,6 +122,8 @@ export class DetailedFishSystem {
   private headingInitialized: boolean[] = []
   private behaviorProfile: BehaviorProfile = { ...DEFAULT_BEHAVIOR_PROFILE }
   private currentQuality: QualityLevel = 'standard'
+  private schoolUpdateFrame = 0
+  private schoolUpdateDeltaTime = 0
   private visualAssets: VisualAssetBundle | null
   private layoutStyle: AquascapeLayoutStyle
   private layoutSeed: number
@@ -2342,9 +2344,19 @@ transformed.y += sin((uFishMotionTime * instanceTailFrequency * 0.45) + instance
       uniform.value = elapsedTime
     })
 
-    this.applyBehaviorForces(bounds, boundsSize, behavior, elapsedTime, safeDeltaTime)
-    this.boids.update(safeDeltaTime)
-    this.syncInstancedMeshes(bounds, behavior, elapsedTime, safeDeltaTime)
+    this.schoolUpdateDeltaTime = ((this.schoolUpdateDeltaTime as number | undefined) ?? 0) + safeDeltaTime
+    const schoolUpdateInterval = this.currentQuality === 'simple' ? 2 : 1
+    const schoolUpdateFrame = (this.schoolUpdateFrame as number | undefined) ?? 0
+    const shouldUpdateSchoolMotion = schoolUpdateFrame % schoolUpdateInterval === 0
+    this.schoolUpdateFrame = schoolUpdateFrame + 1
+
+    if (shouldUpdateSchoolMotion) {
+      const schoolDeltaTime = this.schoolUpdateDeltaTime
+      this.schoolUpdateDeltaTime = 0
+      this.applyBehaviorForces(bounds, boundsSize, behavior, elapsedTime, schoolDeltaTime)
+      this.boids.update(schoolDeltaTime)
+      this.syncInstancedMeshes(bounds, behavior, elapsedTime, schoolDeltaTime)
+    }
     this.updateHeroAnimations(safeDeltaTime)
   }
 

--- a/src/components/GameControlPane.test.ts
+++ b/src/components/GameControlPane.test.ts
@@ -157,13 +157,39 @@ describe('createGameControlPane', () => {
       fps: 58,
       frameTime: 17.2,
       drawCalls: 121,
-      fishVisible: 24
+      fishVisible: 24,
+      triangles: 45_678,
+      geometries: 82,
+      textures: 37,
+      assetLoadTotalMs: 211.4,
+      assetLoadTexturesMs: 80.2,
+      assetLoadModelsMs: 130.8,
+      assetLoadEnvironmentMs: 12.1,
+      fishUpdateCount: 10,
+      fishUpdateLastMs: 2.2,
+      fishUpdateAverageMs: 2.8,
+      waterMotionUpdateCount: 10,
+      waterMotionUpdateLastMs: 1.4,
+      waterMotionUpdateAverageMs: 1.8,
+      godRaysDepthRenderCount: 6,
+      godRaysDepthRenderLastMs: 4.1,
+      godRaysDepthRenderAverageMs: 4.6
     }))
     const pane = createGameControlPane({ store, getPerformanceStats })
 
     expect(paneMock.bindings.some((binding) => binding.config?.label === 'FPS')).toBe(true)
     expect(paneMock.bindings.some((binding) => binding.config?.label === 'Frame ms')).toBe(true)
     expect(paneMock.bindings.some((binding) => binding.config?.label === 'Draw calls')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Triangles')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Geometries')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Textures')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Asset load ms')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Texture load ms')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Model load ms')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Environment load ms')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Fish update avg ms')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'Water update avg ms')).toBe(true)
+    expect(paneMock.bindings.some((binding) => binding.config?.label === 'God rays depth avg ms')).toBe(true)
     expect(paneMock.bindings.some((binding) => binding.config?.label === 'Fish visible')).toBe(true)
 
     vi.advanceTimersByTime(1000)

--- a/src/components/GameControlPane.ts
+++ b/src/components/GameControlPane.ts
@@ -2,17 +2,11 @@ import { Pane } from 'tweakpane'
 import type { GameStore } from '../game/createGameStore'
 import { getDecorContentList, getFishContentList } from '../content/registry'
 import type { GameAppState, Lane, PhotoModeFollowMode } from '../game/types'
+import { createEmptyPerformanceStats, type PerformanceStats } from '../utils/performanceStats'
 
 type GameControlPaneOptions = {
   store: GameStore
   getPerformanceStats?: () => PerformanceStats
-}
-
-type PerformanceStats = {
-  fps: number
-  frameTime: number
-  drawCalls: number
-  fishVisible: number
 }
 
 type PaneControl = {
@@ -67,6 +61,16 @@ const syncPerformanceStats = (params: ControlParams, stats: PerformanceStats): v
   params.fps = Math.round(stats.fps)
   params.frameTime = Number(stats.frameTime.toFixed(1))
   params.drawCalls = Math.max(0, Math.floor(stats.drawCalls))
+  params.triangles = Math.max(0, Math.floor(stats.triangles))
+  params.geometries = Math.max(0, Math.floor(stats.geometries))
+  params.textures = Math.max(0, Math.floor(stats.textures))
+  params.assetLoadTotalMs = Math.max(0, Math.floor(stats.assetLoadTotalMs))
+  params.assetLoadTexturesMs = Math.max(0, Math.floor(stats.assetLoadTexturesMs))
+  params.assetLoadModelsMs = Math.max(0, Math.floor(stats.assetLoadModelsMs))
+  params.assetLoadEnvironmentMs = Math.max(0, Math.floor(stats.assetLoadEnvironmentMs))
+  params.fishUpdateAverageMs = Number(stats.fishUpdateAverageMs.toFixed(1))
+  params.waterMotionUpdateAverageMs = Number(stats.waterMotionUpdateAverageMs.toFixed(1))
+  params.godRaysDepthRenderAverageMs = Number(stats.godRaysDepthRenderAverageMs.toFixed(1))
   params.fishVisible = Math.max(0, Math.floor(stats.fishVisible))
 }
 
@@ -213,12 +217,7 @@ export const createGameControlPane = ({ store, getPerformanceStats }: GameContro
 
   if (getPerformanceStats) {
     const debugFolder = pane.addFolder({ title: 'Debug' })
-    syncPerformanceStats(params, {
-      fps: 0,
-      frameTime: 0,
-      drawCalls: 0,
-      fishVisible: 0
-    })
+    syncPerformanceStats(params, createEmptyPerformanceStats())
     addControl(debugFolder.addBinding(params, 'fps', {
       label: 'FPS',
       readonly: true
@@ -229,6 +228,46 @@ export const createGameControlPane = ({ store, getPerformanceStats }: GameContro
     }))
     addControl(debugFolder.addBinding(params, 'drawCalls', {
       label: 'Draw calls',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'triangles', {
+      label: 'Triangles',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'geometries', {
+      label: 'Geometries',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'textures', {
+      label: 'Textures',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'assetLoadTotalMs', {
+      label: 'Asset load ms',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'assetLoadTexturesMs', {
+      label: 'Texture load ms',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'assetLoadModelsMs', {
+      label: 'Model load ms',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'assetLoadEnvironmentMs', {
+      label: 'Environment load ms',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'fishUpdateAverageMs', {
+      label: 'Fish update avg ms',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'waterMotionUpdateAverageMs', {
+      label: 'Water update avg ms',
+      readonly: true
+    }))
+    addControl(debugFolder.addBinding(params, 'godRaysDepthRenderAverageMs', {
+      label: 'God rays depth avg ms',
       readonly: true
     }))
     addControl(debugFolder.addBinding(params, 'fishVisible', {

--- a/src/components/GodRays.test.ts
+++ b/src/components/GodRays.test.ts
@@ -223,4 +223,69 @@ describe('GodRays underwater scatter', () => {
     expect(internals.bloomPass.threshold).toBeGreaterThan(0.5)
   })
 
+  it('measures depth render duration and call count', () => {
+    const instance = Object.create(GodRaysEffect.prototype) as GodRaysEffect
+    const nowValues = [0, 7]
+    const internals = instance as unknown as {
+      depthRenderStats?: { count: number; lastMs: number; averageMs: number }
+      performance: {
+        now: () => number
+        mark: (name: string) => void
+        measure: (name: string, startMark: string, endMark: string) => void
+        clearMarks: (name?: string) => void
+      }
+      scene: { traverse: (visitor: (object: unknown) => void) => void }
+      renderer: {
+        setRenderTarget: (target: unknown) => void
+        render: (scene: unknown, camera: unknown) => void
+      }
+      depthRenderTarget: unknown
+      camera: unknown
+    }
+
+    internals.performance = {
+      now: () => nowValues.shift() ?? 7,
+      mark: () => undefined,
+      measure: () => undefined,
+      clearMarks: () => undefined
+    }
+    internals.scene = { traverse: () => undefined }
+    internals.renderer = {
+      setRenderTarget: () => undefined,
+      render: () => undefined
+    }
+    internals.depthRenderTarget = {}
+    internals.camera = {}
+
+    const renderDepth = (GodRaysEffect.prototype as unknown as {
+      renderDepth: () => void
+    }).renderDepth.bind(instance)
+
+    renderDepth()
+
+    expect(instance.getDepthRenderStats()).toEqual({
+      count: 1,
+      lastMs: 7,
+      averageMs: 7
+    })
+  })
+
+  it('updates the expensive depth pass every other render while composing each frame', () => {
+    const instance = Object.create(GodRaysEffect.prototype) as GodRaysEffect
+    const internals = instance as unknown as {
+      renderDepth: () => void
+      composer: { render: () => void }
+    }
+
+    internals.renderDepth = vi.fn()
+    internals.composer = { render: vi.fn() }
+
+    instance.render()
+    instance.render()
+    instance.render()
+
+    expect(internals.renderDepth).toHaveBeenCalledTimes(2)
+    expect(internals.composer.render).toHaveBeenCalledTimes(3)
+  })
+
 })

--- a/src/components/GodRays.ts
+++ b/src/components/GodRays.ts
@@ -6,6 +6,12 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 import type { Theme } from '../types/aquarium'
 import type { QualityLevel } from '../types/settings'
 import { defaultTheme } from '../utils/stateSchema'
+import {
+  createEmptySpanTimingStats,
+  measurePerformanceSpan,
+  type PerformanceLike,
+  type SpanTimingStats
+} from '../utils/performanceStats'
 import { ScreenSpaceWaterHazeShader, syncScreenSpaceWaterHazePass } from './screenSpaceWaterHaze'
 
 type GodRayThemeValues = {
@@ -258,6 +264,10 @@ export class GodRaysEffect {
   private renderer: THREE.WebGLRenderer
   private sunMesh: THREE.Group
   private themeValues: GodRayThemeValues = resolveGodRayThemeValues(defaultTheme)
+  private depthRenderStats: SpanTimingStats = createEmptySpanTimingStats()
+  private depthRenderFrame = 0
+  private depthRenderInterval = 2
+  private performance: PerformanceLike = performance
   
   constructor(
     renderer: THREE.WebGLRenderer,
@@ -351,27 +361,47 @@ export class GodRaysEffect {
     syncScreenSpaceWaterHazePass(this.waterHazePass, theme, quality, aspect)
   }
 
+  public setScreenSpaceWaterHazeEnabled(enabled: boolean): void {
+    this.waterHazePass.enabled = enabled
+  }
+
   private renderDepth(): void {
-    // Store original materials
-    const originalMaterials = new Map<THREE.Mesh, THREE.Material | THREE.Material[]>()
-    
-    this.scene.traverse((object) => {
-      if (object instanceof THREE.Mesh) {
-        originalMaterials.set(object, object.material)
-        object.material = this.depthMaterial
+    this.depthRenderStats ??= createEmptySpanTimingStats()
+    measurePerformanceSpan(
+      this.depthRenderStats,
+      {
+        name: 'aquarium:god-rays:render-depth',
+        startMark: 'aquarium:god-rays:render-depth:start',
+        endMark: 'aquarium:god-rays:render-depth:end',
+        performance: this.performance
+      },
+      () => {
+        // Store original materials
+        const originalMaterials = new Map<THREE.Mesh, THREE.Material | THREE.Material[]>()
+
+        this.scene.traverse((object) => {
+          if (object instanceof THREE.Mesh) {
+            originalMaterials.set(object, object.material)
+            object.material = this.depthMaterial
+          }
+        })
+
+        // Render depth
+        this.renderer.setRenderTarget(this.depthRenderTarget)
+        this.renderer.render(this.scene, this.camera)
+
+        // Restore materials
+        originalMaterials.forEach((material, mesh) => {
+          mesh.material = material
+        })
+
+        this.renderer.setRenderTarget(null)
       }
-    })
-    
-    // Render depth
-    this.renderer.setRenderTarget(this.depthRenderTarget)
-    this.renderer.render(this.scene, this.camera)
-    
-    // Restore materials
-    originalMaterials.forEach((material, mesh) => {
-      mesh.material = material
-    })
-    
-    this.renderer.setRenderTarget(null)
+    )
+  }
+
+  public getDepthRenderStats(): SpanTimingStats {
+    return { ...this.depthRenderStats }
   }
   
   update(time: number): void {
@@ -417,7 +447,12 @@ export class GodRaysEffect {
   }
   
   render(): void {
-    this.renderDepth()
+    const depthRenderFrame = this.depthRenderFrame ?? 0
+    const depthRenderInterval = this.depthRenderInterval ?? 2
+    if (depthRenderFrame % depthRenderInterval === 0) {
+      this.renderDepth()
+    }
+    this.depthRenderFrame = depthRenderFrame + 1
     this.composer.render()
   }
   

--- a/src/game/createRenderStateApplier.test.ts
+++ b/src/game/createRenderStateApplier.test.ts
@@ -53,4 +53,24 @@ describe('createRenderStateApplier', () => {
     expect(scene.setPhotoMode).toHaveBeenCalledTimes(2)
     expect(audioManager.setEnabled).toHaveBeenCalledTimes(2)
   })
+
+  it('can force fish groups to reapply after deferred model assets become available', () => {
+    const scene = {
+      applyTheme: vi.fn(),
+      applyFishGroups: vi.fn(() => true),
+      setMotionEnabled: vi.fn(),
+      setPhotoMode: vi.fn()
+    }
+    const audioManager = {
+      setEnabled: vi.fn()
+    }
+    const apply = createRenderStateApplier({ scene, audioManager })
+    const state = createHydratedGameAppState({ nowIso: '2026-03-08T00:00:00.000Z' })
+
+    apply(state)
+    apply(state, { forceFishGroups: true })
+
+    expect(scene.applyTheme).toHaveBeenCalledTimes(1)
+    expect(scene.applyFishGroups).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/game/createRenderStateApplier.ts
+++ b/src/game/createRenderStateApplier.ts
@@ -13,6 +13,10 @@ type AudioBinding = {
   setEnabled: (enabled: boolean) => void
 }
 
+type RenderStateApplyOptions = {
+  forceFishGroups?: boolean
+}
+
 const isSameTheme = (
   left: ReturnType<typeof createAquariumTheme>,
   right: ReturnType<typeof createAquariumTheme>
@@ -35,7 +39,7 @@ export const createRenderStateApplier = (options: {
   let lastTheme: ReturnType<typeof createAquariumTheme> | null = null
   let lastFishGroups: ReturnType<typeof createAquariumFishGroups> | null = null
 
-  return (state: GameAppState): void => {
+  return (state: GameAppState, applyOptions: RenderStateApplyOptions = {}): void => {
     const theme = createAquariumTheme(state)
     if (!lastTheme || !isSameTheme(lastTheme, theme)) {
       options.scene.applyTheme(theme)
@@ -43,7 +47,7 @@ export const createRenderStateApplier = (options: {
     }
 
     const fishGroups = createAquariumFishGroups(state)
-    if (!lastFishGroups || !areFishGroupsEqual(lastFishGroups, fishGroups)) {
+    if (applyOptions.forceFishGroups || !lastFishGroups || !areFishGroupsEqual(lastFishGroups, fishGroups)) {
       const applied = options.scene.applyFishGroups(fishGroups)
       if (applied) {
         lastFishGroups = fishGroups

--- a/src/utils/performanceStats.test.ts
+++ b/src/utils/performanceStats.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createEmptySpanTimingStats,
+  measurePerformanceSpan,
+  readRendererDebugStats
+} from './performanceStats'
+
+describe('readRendererDebugStats', () => {
+  it('normalizes renderer render and memory counters', () => {
+    expect(readRendererDebugStats({
+      render: {
+        calls: 12.8,
+        triangles: 3456.9
+      },
+      memory: {
+        geometries: 18.4,
+        textures: 27.9
+      }
+    })).toEqual({
+      drawCalls: 12,
+      triangles: 3456,
+      geometries: 18,
+      textures: 27
+    })
+  })
+
+  it('falls back to zero when renderer info is unavailable in tests', () => {
+    expect(readRendererDebugStats(undefined)).toEqual({
+      drawCalls: 0,
+      triangles: 0,
+      geometries: 0,
+      textures: 0
+    })
+  })
+})
+
+describe('measurePerformanceSpan', () => {
+  it('records count, last duration, and running average while emitting performance measures', () => {
+    const marks: string[] = []
+    const measures: string[] = []
+    const nowValues = [10, 16, 20, 30]
+    const timing = createEmptySpanTimingStats()
+    const performanceLike = {
+      now: () => nowValues.shift() ?? 30,
+      mark: (name: string) => marks.push(name),
+      measure: (name: string, startMark: string, endMark: string) => {
+        measures.push(`${name}:${startMark}:${endMark}`)
+      },
+      clearMarks: () => undefined
+    }
+
+    const result = measurePerformanceSpan(
+      timing,
+      {
+        name: 'aquarium:test-span',
+        startMark: 'aquarium:test-span:start',
+        endMark: 'aquarium:test-span:end',
+        performance: performanceLike
+      },
+      () => 'measured'
+    )
+    measurePerformanceSpan(
+      timing,
+      {
+        name: 'aquarium:test-span',
+        startMark: 'aquarium:test-span:start',
+        endMark: 'aquarium:test-span:end',
+        performance: performanceLike
+      },
+      () => undefined
+    )
+
+    expect(result).toBe('measured')
+    expect(timing).toEqual({
+      count: 2,
+      lastMs: 10,
+      averageMs: 8
+    })
+    expect(marks).toEqual([
+      'aquarium:test-span:start',
+      'aquarium:test-span:end',
+      'aquarium:test-span:start',
+      'aquarium:test-span:end'
+    ])
+    expect(measures).toEqual([
+      'aquarium:test-span:aquarium:test-span:start:aquarium:test-span:end',
+      'aquarium:test-span:aquarium:test-span:start:aquarium:test-span:end'
+    ])
+  })
+})

--- a/src/utils/performanceStats.ts
+++ b/src/utils/performanceStats.ts
@@ -1,0 +1,149 @@
+export type RendererInfoLike = {
+  render?: {
+    calls?: number
+    triangles?: number
+  }
+  memory?: {
+    geometries?: number
+    textures?: number
+  }
+}
+
+export type RendererDebugStats = {
+  drawCalls: number
+  triangles: number
+  geometries: number
+  textures: number
+}
+
+export type AssetLoadTimingStats = {
+  totalMs: number
+  texturesMs: number
+  modelsMs: number
+  environmentMs: number
+}
+
+export type SpanTimingStats = {
+  count: number
+  lastMs: number
+  averageMs: number
+}
+
+export type PerformanceLike = {
+  now?: () => number
+  mark?: (name: string) => void
+  measure?: (name: string, startMark: string, endMark: string) => void
+  clearMarks?: (name?: string) => void
+}
+
+export type PerformanceStats = RendererDebugStats & {
+  fps: number
+  frameTime: number
+  fishVisible: number
+  assetLoadTotalMs: number
+  assetLoadTexturesMs: number
+  assetLoadModelsMs: number
+  assetLoadEnvironmentMs: number
+  fishUpdateCount: number
+  fishUpdateLastMs: number
+  fishUpdateAverageMs: number
+  waterMotionUpdateCount: number
+  waterMotionUpdateLastMs: number
+  waterMotionUpdateAverageMs: number
+  godRaysDepthRenderCount: number
+  godRaysDepthRenderLastMs: number
+  godRaysDepthRenderAverageMs: number
+}
+
+const toCounter = (value: unknown): number => {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0
+}
+
+export const readRendererDebugStats = (rendererInfo: RendererInfoLike | undefined): RendererDebugStats => ({
+  drawCalls: toCounter(rendererInfo?.render?.calls),
+  triangles: toCounter(rendererInfo?.render?.triangles),
+  geometries: toCounter(rendererInfo?.memory?.geometries),
+  textures: toCounter(rendererInfo?.memory?.textures)
+})
+
+export const createEmptyPerformanceStats = (): PerformanceStats => ({
+  fps: 0,
+  frameTime: 0,
+  fishVisible: 0,
+  drawCalls: 0,
+  triangles: 0,
+  geometries: 0,
+  textures: 0,
+  assetLoadTotalMs: 0,
+  assetLoadTexturesMs: 0,
+  assetLoadModelsMs: 0,
+  assetLoadEnvironmentMs: 0,
+  fishUpdateCount: 0,
+  fishUpdateLastMs: 0,
+  fishUpdateAverageMs: 0,
+  waterMotionUpdateCount: 0,
+  waterMotionUpdateLastMs: 0,
+  waterMotionUpdateAverageMs: 0,
+  godRaysDepthRenderCount: 0,
+  godRaysDepthRenderLastMs: 0,
+  godRaysDepthRenderAverageMs: 0
+})
+
+export const applyAssetLoadTimings = (
+  stats: PerformanceStats,
+  timings: AssetLoadTimingStats | undefined
+): void => {
+  stats.assetLoadTotalMs = toCounter(timings?.totalMs)
+  stats.assetLoadTexturesMs = toCounter(timings?.texturesMs)
+  stats.assetLoadModelsMs = toCounter(timings?.modelsMs)
+  stats.assetLoadEnvironmentMs = toCounter(timings?.environmentMs)
+}
+
+export const createEmptySpanTimingStats = (): SpanTimingStats => ({
+  count: 0,
+  lastMs: 0,
+  averageMs: 0
+})
+
+export const recordSpanTiming = (stats: SpanTimingStats, durationMs: number): void => {
+  const safeDuration = typeof durationMs === 'number' && Number.isFinite(durationMs)
+    ? Math.max(0, durationMs)
+    : 0
+  const nextCount = stats.count + 1
+  stats.lastMs = safeDuration
+  stats.averageMs = ((stats.averageMs * stats.count) + safeDuration) / nextCount
+  stats.count = nextCount
+}
+
+const defaultPerformance = (): PerformanceLike | undefined => (
+  typeof performance === 'undefined' ? undefined : performance
+)
+
+export const measurePerformanceSpan = <T>(
+  stats: SpanTimingStats,
+  options: {
+    name: string
+    startMark: string
+    endMark: string
+    performance?: PerformanceLike
+  },
+  run: () => T
+): T => {
+  const performanceLike = options.performance ?? defaultPerformance()
+  const now = performanceLike?.now?.bind(performanceLike) ?? (() => 0)
+  performanceLike?.mark?.(options.startMark)
+  const start = now()
+
+  try {
+    return run()
+  } finally {
+    const duration = now() - start
+    recordSpanTiming(stats, duration)
+    performanceLike?.mark?.(options.endMark)
+    performanceLike?.measure?.(options.name, options.startMark, options.endMark)
+    performanceLike?.clearMarks?.(options.startMark)
+    performanceLike?.clearMarks?.(options.endMark)
+  }
+}

--- a/src/utils/performanceTuning.test.ts
+++ b/src/utils/performanceTuning.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { appendPerformanceTuningQuery, resolvePerformanceTuningOptions } from './performanceTuning'
+
+describe('resolvePerformanceTuningOptions', () => {
+  it('parses measurement A/B switches from URL search params', () => {
+    expect(resolvePerformanceTuningOptions('?perfPost=0&perfHaze=0&perfShadow=2048')).toEqual({
+      postProcessingEnabled: false,
+      screenSpaceHazeEnabled: false,
+      shadowMapSize: 2048
+    })
+  })
+
+  it('keeps defaults when unsupported values are provided', () => {
+    expect(resolvePerformanceTuningOptions('?perfPost=1&perfHaze=1&perfShadow=huge')).toEqual({
+      postProcessingEnabled: true,
+      screenSpaceHazeEnabled: true,
+      shadowMapSize: null
+    })
+  })
+})
+
+describe('appendPerformanceTuningQuery', () => {
+  it('adds env-driven switches to the measurement URL without dropping existing params', () => {
+    expect(appendPerformanceTuningQuery('http://127.0.0.1:5173/meaningless/?sample=1', {
+      AQUARIUM_PERFORMANCE_POST_PROCESSING: '0',
+      AQUARIUM_PERFORMANCE_HAZE: '0',
+      AQUARIUM_PERFORMANCE_SHADOW_MAP_SIZE: '1024'
+    })).toBe('http://127.0.0.1:5173/meaningless/?sample=1&perfPost=0&perfHaze=0&perfShadow=1024')
+  })
+})

--- a/src/utils/performanceTuning.ts
+++ b/src/utils/performanceTuning.ts
@@ -1,0 +1,54 @@
+export type PerformanceTuningOptions = {
+  postProcessingEnabled: boolean
+  screenSpaceHazeEnabled: boolean
+  shadowMapSize: number | null
+}
+
+export type PerformanceTuningEnv = Record<string, string | undefined>
+
+export const DEFAULT_PERFORMANCE_TUNING: PerformanceTuningOptions = {
+  postProcessingEnabled: true,
+  screenSpaceHazeEnabled: true,
+  shadowMapSize: null
+}
+
+const parseBooleanSwitch = (value: string | null, fallback: boolean): boolean => {
+  if (value === '0' || value === 'false') return false
+  if (value === '1' || value === 'true') return true
+  return fallback
+}
+
+const parseShadowMapSize = (value: string | null): number | null => {
+  if (!value) return null
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed)) return null
+  return parsed >= 512 && parsed <= 4096 ? parsed : null
+}
+
+export const resolvePerformanceTuningOptions = (search: string): PerformanceTuningOptions => {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+
+  return {
+    postProcessingEnabled: parseBooleanSwitch(params.get('perfPost'), DEFAULT_PERFORMANCE_TUNING.postProcessingEnabled),
+    screenSpaceHazeEnabled: parseBooleanSwitch(params.get('perfHaze'), DEFAULT_PERFORMANCE_TUNING.screenSpaceHazeEnabled),
+    shadowMapSize: parseShadowMapSize(params.get('perfShadow'))
+  }
+}
+
+export const appendPerformanceTuningQuery = (
+  url: string,
+  env: PerformanceTuningEnv
+): string => {
+  const measurementUrl = new URL(url)
+  if (env.AQUARIUM_PERFORMANCE_POST_PROCESSING === '0') {
+    measurementUrl.searchParams.set('perfPost', '0')
+  }
+  if (env.AQUARIUM_PERFORMANCE_HAZE === '0') {
+    measurementUrl.searchParams.set('perfHaze', '0')
+  }
+  const shadowMapSize = parseShadowMapSize(env.AQUARIUM_PERFORMANCE_SHADOW_MAP_SIZE ?? null)
+  if (shadowMapSize !== null) {
+    measurementUrl.searchParams.set('perfShadow', String(shadowMapSize))
+  }
+  return measurementUrl.toString()
+}

--- a/src/utils/renderScale.test.ts
+++ b/src/utils/renderScale.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAdaptiveRenderScale } from './renderScale'
+
+describe('resolveAdaptiveRenderScale', () => {
+  it('drops one tier when sustained frame time is above budget', () => {
+    expect(resolveAdaptiveRenderScale({
+      currentScale: 1,
+      averageFrameTimeMs: 36,
+      stressedSampleCount: 3,
+      stableSampleCount: 0
+    })).toBe(0.85)
+  })
+
+  it('steps back up after sustained stable frame times', () => {
+    expect(resolveAdaptiveRenderScale({
+      currentScale: 0.85,
+      averageFrameTimeMs: 17,
+      stressedSampleCount: 0,
+      stableSampleCount: 6
+    })).toBe(1)
+  })
+
+  it('does not drop below the minimum scale', () => {
+    expect(resolveAdaptiveRenderScale({
+      currentScale: 0.7,
+      averageFrameTimeMs: 42,
+      stressedSampleCount: 4,
+      stableSampleCount: 0
+    })).toBe(0.7)
+  })
+})

--- a/src/utils/renderScale.ts
+++ b/src/utils/renderScale.ts
@@ -1,0 +1,42 @@
+export type AdaptiveRenderScaleInput = {
+  currentScale: number
+  averageFrameTimeMs: number
+  stressedSampleCount: number
+  stableSampleCount: number
+}
+
+const renderScaleTiers = [0.7, 0.85, 1] as const
+const stressedFrameTimeMs = 28
+const stableFrameTimeMs = 20
+const requiredStressedSamples = 3
+const requiredStableSamples = 6
+
+const resolveTierIndex = (scale: number): number => {
+  const index = renderScaleTiers.findIndex((tier) => scale <= tier + 0.001)
+  return index === -1 ? renderScaleTiers.length - 1 : index
+}
+
+export const resolveAdaptiveRenderScale = ({
+  currentScale,
+  averageFrameTimeMs,
+  stressedSampleCount,
+  stableSampleCount
+}: AdaptiveRenderScaleInput): number => {
+  const tierIndex = resolveTierIndex(currentScale)
+
+  if (
+    averageFrameTimeMs >= stressedFrameTimeMs &&
+    stressedSampleCount >= requiredStressedSamples
+  ) {
+    return renderScaleTiers[Math.max(0, tierIndex - 1)]
+  }
+
+  if (
+    averageFrameTimeMs <= stableFrameTimeMs &&
+    stableSampleCount >= requiredStableSamples
+  ) {
+    return renderScaleTiers[Math.min(renderScaleTiers.length - 1, tierIndex + 1)]
+  }
+
+  return renderScaleTiers[tierIndex]
+}

--- a/src/utils/updateCadence.test.ts
+++ b/src/utils/updateCadence.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRunQualityCadencedUpdate } from './updateCadence'
+
+describe('shouldRunQualityCadencedUpdate', () => {
+  it('runs simple quality updates every other frame', () => {
+    expect(shouldRunQualityCadencedUpdate({ frame: 0, quality: 'simple' })).toBe(true)
+    expect(shouldRunQualityCadencedUpdate({ frame: 1, quality: 'simple' })).toBe(false)
+    expect(shouldRunQualityCadencedUpdate({ frame: 2, quality: 'simple' })).toBe(true)
+  })
+
+  it('keeps standard quality updates running every frame', () => {
+    expect(shouldRunQualityCadencedUpdate({ frame: 0, quality: 'standard' })).toBe(true)
+    expect(shouldRunQualityCadencedUpdate({ frame: 1, quality: 'standard' })).toBe(true)
+  })
+})

--- a/src/utils/updateCadence.ts
+++ b/src/utils/updateCadence.ts
@@ -1,0 +1,14 @@
+export type CadencedQuality = 'simple' | 'standard'
+
+export type QualityCadenceOptions = {
+  frame: number
+  quality: CadencedQuality
+}
+
+export const shouldRunQualityCadencedUpdate = ({
+  frame,
+  quality
+}: QualityCadenceOptions): boolean => {
+  const interval = quality === 'simple' ? 2 : 1
+  return frame % interval === 0
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,53 @@
 import { defineConfig } from 'vite'
 import glsl from 'vite-plugin-glsl'
 
+const resolveThreeChunk = (id: string): string | null => {
+  if (id.includes('/node_modules/three/examples/jsm/postprocessing/')) {
+    return 'three-postprocessing'
+  }
+  if (id.includes('/node_modules/three/examples/jsm/loaders/')) {
+    return 'three-loaders'
+  }
+  if (id.includes('/node_modules/three/examples/jsm/utils/')) {
+    return 'three-utils'
+  }
+  if (id.includes('/node_modules/three/examples/jsm/controls/')) {
+    return 'three-controls'
+  }
+  if (id.includes('/node_modules/three/examples/jsm/')) {
+    return 'three-examples'
+  }
+  if (
+    id.includes('/node_modules/three/') ||
+    id.includes('/node_modules/.vite/deps/three.module-') ||
+    id.endsWith('/node_modules/.vite/deps/three.js')
+  ) {
+    return 'three-core'
+  }
+  return null
+}
+
 export default defineConfig({
   plugins: [glsl()],
   base: '/meaningless/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',
-    rollupOptions: {
+    rolldownOptions: {
+      preserveEntrySignatures: false,
       output: {
-        manualChunks(id) {
-          if (id.includes('/node_modules/three/examples/jsm/')) {
-            return 'three-addons'
-          }
-          if (id.includes('/node_modules/three/')) {
-            return 'three-core'
-          }
-          return undefined
+        strictExecutionOrder: true,
+        codeSplitting: {
+          includeDependenciesRecursively: false,
+          maxSize: 450 * 1024,
+          groups: [
+            {
+              name: resolveThreeChunk,
+              test(id) {
+                return resolveThreeChunk(id) !== null
+              }
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add performance measurement tooling and debug stats for renderer, asset loading, fish update, water motion, and God rays depth pass timing.
- Reduce aquarium rendering cost by removing glass overlays, merging lighting sheets, throttling God rays depth rendering, lowering shadow map sizes, and bypassing post-processing on simple quality.
- Split boot/deferred visual assets, add adaptive render scale, simple-quality fish/water update LOD, and remove bright procedural sand ripples from the nature-showcase beach.
- Split Three.js production chunks with Rolldown code splitting to remove the 500 kB chunk warning.

## Impact

This keeps the planted showcase visually focused while reducing draw calls, startup asset load work, and per-frame update cost. It also adds a repeatable `npm run measure:performance` harness for future comparisons.

## Validation

- `npm run test` — 48 files passed, 371 passed, 18 skipped
- `npm run build` — passed, no 500 kB chunk warning
- `npm run typecheck` — passed
- `npm run verify:soc` — passed, no dependency violations
- `npm run lint` — passed
- Headless performance smoke captured in `/tmp/meaningless-perf-final-plan-smoke.json` during implementation: drawCalls 162, triangles 740,107, geometries 44, textures 107, assetLoadTotalMs 331ms

Note: `.serena/memories/*` local agent notes were intentionally left uncommitted.